### PR TITLE
Kind Checker: CLI Integration

### DIFF
--- a/lambda-buffers-compiler/app/LambdaBuffers/Compiler/Cli/Compile.hs
+++ b/lambda-buffers-compiler/app/LambdaBuffers/Compiler/Cli/Compile.hs
@@ -8,13 +8,12 @@ import Data.ProtoLens.TextFormat qualified as PbText
 import Data.Text.Lazy qualified as Text
 import Data.Text.Lazy.IO qualified as Text
 import LambdaBuffers.Compiler.KindCheck (check)
-import LambdaBuffers.Compiler.KindCheck.Context (getAllContext)
 import LambdaBuffers.Compiler.ProtoCompat (
   FromProtoErr (NamingError, ProtoError),
   IsMessage (fromProto, toProto),
  )
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as ProtoCompat
-import Proto.Compiler as ProtoLib (CompilerInput, CompilerResult)
+import Proto.Compiler as ProtoLib (CompilerInput, CompilerOutput)
 import System.FilePath.Lens (extension)
 
 data CompileOpts = CompileOpts
@@ -37,7 +36,7 @@ compile opts = do
       ProtoError pe -> print $ "Encountered a proto error " <> show pe
     Right compIn' -> do
       print @String "Successfully processed the CompilerInput"
-      let result = either (RCompilerFailure . KCErr) (RCompilerOutput . CompilerOutput . fmap kindConvert . getAllContext) $ check compIn'
+      let result = check compIn'
       writeCompilerOutput (opts ^. output) (toProto result)
   return ()
 
@@ -53,7 +52,7 @@ readCompilerInput fp = do
       return $ PbText.readMessageOrDie content
     _ -> error $ "Unknown CompilerInput format " <> ext
 
-writeCompilerOutput :: FilePath -> ProtoLib.CompilerResult -> IO ()
+writeCompilerOutput :: FilePath -> ProtoLib.CompilerOutput -> IO ()
 writeCompilerOutput fp cr = do
   let ext = fp ^. extension
   case ext of

--- a/lambda-buffers-compiler/app/LambdaBuffers/Compiler/Cli/Compile.hs
+++ b/lambda-buffers-compiler/app/LambdaBuffers/Compiler/Cli/Compile.hs
@@ -7,9 +7,18 @@ import Data.ProtoLens qualified as Pb
 import Data.ProtoLens.TextFormat qualified as PbText
 import Data.Text.Lazy qualified as Text
 import Data.Text.Lazy.IO qualified as Text
-import LambdaBuffers.Compiler.ProtoCompat (FromProtoErr (NamingError, ProtoError), IsMessage (fromProto, toProto))
+import LambdaBuffers.Compiler.KindCheck (check)
+import LambdaBuffers.Compiler.KindCheck.Context (getAllContext)
+import LambdaBuffers.Compiler.ProtoCompat (
+  CompilerFailure (KCErr),
+  CompilerOutput (CompilerOutput),
+  CompilerResult (RCompilerFailure, RCompilerOutput),
+  FromProtoErr (NamingError, ProtoError),
+  IsMessage (fromProto, toProto),
+  kindConvert,
+ )
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as ProtoCompat
-import Proto.Compiler (CompilerInput)
+import Proto.Compiler as ProtoLib (CompilerInput, CompilerResult)
 import System.FilePath.Lens (extension)
 
 data CompileOpts = CompileOpts
@@ -19,6 +28,8 @@ data CompileOpts = CompileOpts
   deriving stock (Eq, Show)
 
 makeLenses ''CompileOpts
+
+-- NOTE(cstml) - let's use Katip instead of print.
 
 -- | Compile LambdaBuffers modules
 compile :: CompileOpts -> IO ()
@@ -30,8 +41,8 @@ compile opts = do
       ProtoError pe -> print $ "Encountered a proto error " <> show pe
     Right compIn' -> do
       print @String "Successfully processed the CompilerInput"
-      writeCompilerOutput (opts ^. output) (toProto compIn')
-
+      let result = either (RCompilerFailure . KCErr) (RCompilerOutput . CompilerOutput . fmap kindConvert . getAllContext) $ check compIn'
+      writeCompilerOutput (opts ^. output) (toProto result)
   return ()
 
 readCompilerInput :: FilePath -> IO CompilerInput
@@ -46,11 +57,10 @@ readCompilerInput fp = do
       return $ PbText.readMessageOrDie content
     _ -> error $ "Unknown CompilerInput format " <> ext
 
--- FIXME(bladyjoker): Do this properly when you figure out what the CompilerOutput is.
-writeCompilerOutput :: FilePath -> CompilerInput -> IO ()
-writeCompilerOutput fp co = do
+writeCompilerOutput :: FilePath -> ProtoLib.CompilerResult -> IO ()
+writeCompilerOutput fp cr = do
   let ext = fp ^. extension
   case ext of
-    ".pb" -> BS.writeFile fp (Pb.encodeMessage co)
-    ".textproto" -> Text.writeFile fp (Text.pack . show $ PbText.pprintMessage co)
+    ".pb" -> BS.writeFile fp (Pb.encodeMessage cr)
+    ".textproto" -> Text.writeFile fp (Text.pack . show $ PbText.pprintMessage cr)
     _ -> error $ "Unknown CompilerOutput format " <> ext

--- a/lambda-buffers-compiler/app/LambdaBuffers/Compiler/Cli/Compile.hs
+++ b/lambda-buffers-compiler/app/LambdaBuffers/Compiler/Cli/Compile.hs
@@ -10,12 +10,8 @@ import Data.Text.Lazy.IO qualified as Text
 import LambdaBuffers.Compiler.KindCheck (check)
 import LambdaBuffers.Compiler.KindCheck.Context (getAllContext)
 import LambdaBuffers.Compiler.ProtoCompat (
-  CompilerFailure (KCErr),
-  CompilerOutput (CompilerOutput),
-  CompilerResult (RCompilerFailure, RCompilerOutput),
   FromProtoErr (NamingError, ProtoError),
   IsMessage (fromProto, toProto),
-  kindConvert,
  )
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as ProtoCompat
 import Proto.Compiler as ProtoLib (CompilerInput, CompilerResult)

--- a/lambda-buffers-compiler/app/Main.hs
+++ b/lambda-buffers-compiler/app/Main.hs
@@ -23,8 +23,6 @@ import Options.Applicative (
   subparser,
  )
 
-import LambdaBuffers.Compiler.KindCheck (check)
-
 newtype Command = Compile CompileOpts
 
 inputPathP :: Parser FilePath

--- a/lambda-buffers-compiler/app/Main.hs
+++ b/lambda-buffers-compiler/app/Main.hs
@@ -23,8 +23,9 @@ import Options.Applicative (
   subparser,
  )
 
-newtype Command
-  = Compile CompileOpts
+import LambdaBuffers.Compiler.KindCheck (check)
+
+newtype Command = Compile CompileOpts
 
 inputPathP :: Parser FilePath
 inputPathP =

--- a/lambda-buffers-compiler/lambda-buffers-compiler.cabal
+++ b/lambda-buffers-compiler/lambda-buffers-compiler.cabal
@@ -38,6 +38,7 @@ common common-language
     DeriveTraversable
     DerivingStrategies
     DoAndIfThenElse
+    DuplicateRecordFields
     EmptyCase
     EmptyDataDecls
     EmptyDataDeriving
@@ -59,6 +60,7 @@ common common-language
     NamedFieldPuns
     NamedWildCards
     NumericUnderscores
+    OverloadedLabels
     OverloadedStrings
     PartialTypeSignatures
     PatternGuards
@@ -148,4 +150,8 @@ test-suite tests
 
   other-modules:
     Test.KindCheck
+    Test.Samples
+    Test.Samples.Proto.CompilerInput
+    Test.Samples.Proto.Module
+    Test.Samples.Proto.SourceInfo
     Test.TypeClassCheck

--- a/lambda-buffers-compiler/lambda-buffers-compiler.cabal
+++ b/lambda-buffers-compiler/lambda-buffers-compiler.cabal
@@ -114,6 +114,7 @@ library
 
   hs-source-dirs:  src
 
+-- note(cstml): should we name this something shorter? lb-cli?
 executable lambda-buffers-compiler-cli
   import:         common-language
   import:         common-imports

--- a/lambda-buffers-compiler/lambda-buffers-compiler.cabal
+++ b/lambda-buffers-compiler/lambda-buffers-compiler.cabal
@@ -154,4 +154,5 @@ test-suite tests
     Test.Samples.Proto.CompilerInput
     Test.Samples.Proto.Module
     Test.Samples.Proto.SourceInfo
+    Test.Samples.Proto.TyDef
     Test.TypeClassCheck

--- a/lambda-buffers-compiler/lambda-buffers-compiler.cabal
+++ b/lambda-buffers-compiler/lambda-buffers-compiler.cabal
@@ -152,6 +152,7 @@ test-suite tests
     Test.KindCheck
     Test.Samples
     Test.Samples.Proto.CompilerInput
+    Test.Samples.Proto.Helpers
     Test.Samples.Proto.Module
     Test.Samples.Proto.SourceInfo
     Test.Samples.Proto.TyDef

--- a/lambda-buffers-compiler/lambda-buffers-compiler.cabal
+++ b/lambda-buffers-compiler/lambda-buffers-compiler.cabal
@@ -103,7 +103,9 @@ library
   exposed-modules:
     LambdaBuffers.Compiler.KindCheck
     LambdaBuffers.Compiler.KindCheck.Context
+    LambdaBuffers.Compiler.KindCheck.Derivation
     LambdaBuffers.Compiler.KindCheck.Inference
+    LambdaBuffers.Compiler.KindCheck.Judgement
     LambdaBuffers.Compiler.KindCheck.Kind
     LambdaBuffers.Compiler.KindCheck.Type
     LambdaBuffers.Compiler.KindCheck.Variable

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
@@ -1,8 +1,3 @@
-{-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 module LambdaBuffers.Compiler.KindCheck (
   -- * Kindchecking functions.
   check,
@@ -59,7 +54,6 @@ import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P (
   KindRefType (KType),
   KindType (KindArrow, KindRef),
   LocalRef,
-  MiscError (ImpossibleError),
   Module,
   ModuleName,
   Product (..),
@@ -181,7 +175,7 @@ runKindCheck = reinterpret $ \case
       InferRecursiveSubstitutionErr _ ->
         throwError . P.CompKindCheckError $ P.RecursiveKindError $ tyDef2TyName td
       InferImpossibleErr t ->
-        throwError . P.CompMiscError $ P.ImpossibleError t
+        throwError . P.InternalError $ t
 
     var2VarName = \case
       LocalRef n -> P.VarName n emptySourceInfo

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
@@ -4,13 +4,12 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module LambdaBuffers.Compiler.KindCheck (
+  -- * Kindchecking functions.
   check,
   check_,
+
+  -- * Testing Utils.
   foldWithSum,
-
-  -- * Testing Utils
-
-  -- * Utilities -- exported for testing
   foldWithArrow,
   foldWithProduct,
 ) where

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
@@ -43,9 +43,9 @@ import Data.Map qualified as M
 -- - double declaration of a type
 
 -- | Kind Check failure types.
-type KindCheckFailure = P.KindCheckErr
+type CompilerErr = P.CompilerError
 
-type Err = Error KindCheckFailure
+type Err = Error CompilerErr
 
 type ModName = Text
 
@@ -78,15 +78,15 @@ makeEffect ''KindCheck
 
 --------------------------------------------------------------------------------
 
-runCheck :: Eff (Check ': '[]) a -> Either KindCheckFailure a
+runCheck :: Eff (Check ': '[]) a -> Either CompilerErr a
 runCheck = run . runError . runKindCheck . localStrategy . moduleStrategy . globalStrategy
 
 -- | Run the check - return the validated context or the failure.
-check :: P.CompilerInput -> Either KindCheckFailure Context
+check :: P.CompilerInput -> Either CompilerErr Context
 check = runCheck . kCheck
 
 -- | Run the check - drop the result if it succeeds.
-check_ :: P.CompilerInput -> Either KindCheckFailure ()
+check_ :: P.CompilerInput -> Either CompilerErr ()
 check_ = void . check
 
 --------------------------------------------------------------------------------

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
@@ -48,13 +48,8 @@ import Data.Map qualified as M
 -- | Kind Check failure types.
 data KindCheckFailure
   = CheckFailure String
-  | LookupVarFailure Text
   | LookupRefFailure P.TyRef
   | AppWrongArgKind Kind Kind -- Expected Kind got Kind
-  | AppToManyArgs Int
-  | InvalidProto Text
-  | AppNoArgs -- No args
-  | InvalidType InferErr
   | InferenceFailed P.TyDef InferErr
   | InconsistentType P.TyDef
   deriving stock (Show, Eq)

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
@@ -39,7 +39,6 @@ import LambdaBuffers.Compiler.KindCheck.Inference (
  )
 import LambdaBuffers.Compiler.KindCheck.Inference qualified as I
 import LambdaBuffers.Compiler.KindCheck.Type (Type (App))
-import LambdaBuffers.Compiler.KindCheck.Type qualified as P
 import LambdaBuffers.Compiler.KindCheck.Variable (Variable (ForeignRef, LocalRef))
 import LambdaBuffers.Compiler.ProtoCompat (kind2ProtoKind)
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P (

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck.hs
@@ -47,9 +47,7 @@ import Data.Map qualified as M
 
 -- | Kind Check failure types.
 data KindCheckFailure
-  = CheckFailure String
-  | LookupRefFailure P.TyRef
-  | AppWrongArgKind Kind Kind -- Expected Kind got Kind
+  = InvalidType InferErr
   | InferenceFailed P.TyDef InferErr
   | InconsistentType P.TyDef
   deriving stock (Show, Eq)

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Context.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Context.hs
@@ -14,8 +14,6 @@ import Prettyprinter (
   (<+>),
  )
 
--- import LambdaBuffers.Compiler.ProtoCompat (TyRef)
--- type Variable = TyRef
 
 data Context = Context
   { _context :: M.Map Variable Kind

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Context.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Context.hs
@@ -14,7 +14,6 @@ import Prettyprinter (
   (<+>),
  )
 
-
 data Context = Context
   { _context :: M.Map Variable Kind
   , _addContext :: M.Map Variable Kind

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Context.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Context.hs
@@ -3,7 +3,7 @@ module LambdaBuffers.Compiler.KindCheck.Context (Context (Context), context, add
 import Control.Lens (makeLenses, (^.))
 import Data.Map qualified as M
 import LambdaBuffers.Compiler.KindCheck.Kind (Kind)
-import LambdaBuffers.Compiler.KindCheck.Variable (Atom)
+import LambdaBuffers.Compiler.KindCheck.Variable (Variable)
 import Prettyprinter (
   Doc,
   Pretty (pretty),
@@ -14,9 +14,12 @@ import Prettyprinter (
   (<+>),
  )
 
+-- import LambdaBuffers.Compiler.ProtoCompat (TyRef)
+-- type Variable = TyRef
+
 data Context = Context
-  { _context :: M.Map Atom Kind
-  , _addContext :: M.Map Atom Kind
+  { _context :: M.Map Variable Kind
+  , _addContext :: M.Map Variable Kind
   }
   deriving stock (Show, Eq)
 
@@ -27,7 +30,7 @@ instance Pretty Context where
     [] -> "Γ"
     ctx -> "Γ" <+> "∪" <+> braces (setPretty ctx)
     where
-      setPretty :: [(Atom, Kind)] -> Doc ann
+      setPretty :: [(Variable, Kind)] -> Doc ann
       setPretty = hsep . punctuate comma . fmap (\(v, t) -> pretty v <> ":" <+> pretty t)
 
 instance Semigroup Context where
@@ -37,5 +40,5 @@ instance Monoid Context where
   mempty = Context mempty mempty
 
 -- | Utility to unify the two.
-getAllContext :: Context -> M.Map Atom Kind
+getAllContext :: Context -> M.Map Variable Kind
 getAllContext c = c ^. context <> c ^. addContext

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Derivation.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Derivation.hs
@@ -1,0 +1,30 @@
+module LambdaBuffers.Compiler.KindCheck.Derivation (
+  Derivation (Axiom, Abstraction, Application),
+) where
+
+import LambdaBuffers.Compiler.KindCheck.Judgement (Judgement)
+import Prettyprinter (
+  Doc,
+  Pretty (pretty),
+  encloseSep,
+  hang,
+  lbracket,
+  line,
+  rbracket,
+  space,
+ )
+
+data Derivation
+  = Axiom Judgement
+  | Abstraction Judgement Derivation
+  | Application Judgement Derivation Derivation
+  deriving stock (Show, Eq)
+
+instance Pretty Derivation where
+  pretty x = case x of
+    Axiom j -> hang 2 $ pretty j
+    Abstraction j d -> dNest j [d]
+    Application j d1 d2 -> dNest j [d1, d2]
+    where
+      dNest :: forall a b c. (Pretty a, Pretty b) => a -> [b] -> Doc c
+      dNest j ds = pretty j <> line <> hang 2 (encloseSep (lbracket <> space) rbracket (space <> "∧" <> space) (pretty <$> ds))

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Inference.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Inference.hs
@@ -39,11 +39,9 @@ import Prettyprinter (
   (<+>),
  )
 
-import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P (
-  InferenceErr (..),
- )
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P
 
-type InferErr = P.InferenceErr
+type InferErr = P.CompilerError
 
 newtype Constraint = Constraint (Kind, Kind)
   deriving stock (Show, Eq)
@@ -132,7 +130,7 @@ derive x = do
       (DC vs) <- get
       case vs of
         a : as -> put (DC as) >> pure a
-        [] -> throwError $ P.ImpossibleErr "End of infinite stream"
+        [] -> throwError . P.CompMiscError . P.ImpossibleErr $ "End of infinite stream"
 
 {- | Gets the binding from the context - if the variable is not bound throw an
  error.
@@ -142,7 +140,7 @@ getBinding t = do
   ctx <- asks getAllContext
   case ctx M.!? t of
     Just x -> pure x
-    Nothing -> throwError $ P.UnboundTermErr $ (T.pack . show . pretty) t
+    Nothing -> throwError $ P.CompKindCheckError $ P.UnboundTermErr $ (T.pack . show . pretty) t
 
 -- | Gets kind from a derivation.
 topKind :: Getter Derivation Kind

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Judgement.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Judgement.hs
@@ -1,0 +1,12 @@
+module LambdaBuffers.Compiler.KindCheck.Judgement (Judgement (Judgement), getJudgement) where
+
+import LambdaBuffers.Compiler.KindCheck.Context (Context)
+import LambdaBuffers.Compiler.KindCheck.Kind (Kind)
+import LambdaBuffers.Compiler.KindCheck.Type (Type)
+import Prettyprinter (Pretty (pretty), (<+>))
+
+newtype Judgement = Judgement {getJudgement :: (Context, Type, Kind)}
+  deriving stock (Show, Eq)
+
+instance Pretty Judgement where
+  pretty (Judgement (c, t, k)) = pretty c <> " ⊢ " <> pretty t <+> ":" <+> pretty k

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Type.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Type.hs
@@ -1,13 +1,25 @@
-module LambdaBuffers.Compiler.KindCheck.Type (Type (Var, Abs, App)) where
+{-# LANGUAGE PatternSynonyms #-}
 
-import LambdaBuffers.Compiler.KindCheck.Variable (Var)
+module LambdaBuffers.Compiler.KindCheck.Type (
+  Type (Var, Abs, App),
+  pattern Σ,
+  pattern Π,
+) where
+
+import LambdaBuffers.Compiler.KindCheck.Variable (Variable (LocalRef))
 import Prettyprinter (Doc, Pretty (pretty), parens, (<+>))
 
 data Type
-  = Var Var
+  = Var Variable
   | App Type Type
-  | Abs Var Type
+  | Abs Variable Type
   deriving stock (Eq, Show)
+
+pattern Σ :: Type -> Type -> Type
+pattern Σ t1 t2 = App (App (Var (LocalRef "Σ")) t1) t2
+
+pattern Π :: Type -> Type -> Type
+pattern Π t1 t2 = App (App (Var (LocalRef "Π")) t1) t2
 
 instance Pretty Type where
   pretty = \case

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Variable.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Variable.hs
@@ -1,6 +1,18 @@
-module LambdaBuffers.Compiler.KindCheck.Variable (Atom, Var) where
+module LambdaBuffers.Compiler.KindCheck.Variable (Variable (LocalRef, ForeignRef), Atom) where
 
 import Data.Text (Text)
+import Prettyprinter (Pretty (pretty), concatWith)
 
+-- import LambdaBuffers.Compiler.ProtoCompat (TyRef)
 type Atom = Text
-type Var = Text
+
+-- type Variable = TyRef
+data Variable
+  = LocalRef Text
+  | ForeignRef [Text] Text
+  deriving stock (Eq, Ord, Show)
+
+instance Pretty Variable where
+  pretty = \case
+    LocalRef a -> pretty a
+    ForeignRef ms a -> concatWith (\x y -> x <> "." <> y) (pretty <$> (ms <> [a]))

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Variable.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/KindCheck/Variable.hs
@@ -3,10 +3,8 @@ module LambdaBuffers.Compiler.KindCheck.Variable (Variable (LocalRef, ForeignRef
 import Data.Text (Text)
 import Prettyprinter (Pretty (pretty), concatWith)
 
--- import LambdaBuffers.Compiler.ProtoCompat (TyRef)
 type Atom = Text
 
--- type Variable = TyRef
 data Variable
   = LocalRef Text
   | ForeignRef [Text] Text

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
@@ -539,23 +539,12 @@ instance IsMessage P.CompilerError CompilerError where
     CompKindCheckError kcerr -> defMessage & P.compKindCheckErr .~ toProto kcerr
     CompMiscError miscerr -> defMessage & P.compMiscErr .~ toProto miscerr
 
-instance IsMessage P.ValidatedTyDef (TyRef, (Ty, Kind)) where
-  fromProto vt =
-    (,)
-      <$> fromProto (vt ^. P.tyRef)
-      <*> ( (,)
-              <$> fromProto (vt ^. P.tyBody)
-              <*> fromProto (vt ^. P.tyKind)
-          )
-  toProto (tyref, (tybo, tyki)) =
-    defMessage
-      & P.tyRef .~ toProto tyref
-      & P.tyBody .~ toProto tybo
-      & P.tyKind .~ toProto tyki
-
 instance IsMessage P.CompilerResult CompilerResult where
-  fromProto co = CompilerResult . M.fromList <$> traverse fromProto (co ^. P.typeDefs)
-  toProto (CompilerResult tds) = defMessage & P.typeDefs .~ (toProto <$> M.toList tds)
+  fromProto c =
+    if c == defMessage
+      then pure CompilerResult
+      else throwProtoError EmptyField
+  toProto CompilerResult = defMessage
 
 instance IsMessage P.CompilerOutput CompilerOutput where
   fromProto co = case co ^. P.maybe'compilerOutput of

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
@@ -515,7 +515,7 @@ instance IsMessage P.CompilerResult CompilerResult where
     RCompilerFailure cf -> defMessage & P.failedCompilation .~ toProto cf
     RCompilerOutput co -> defMessage & P.compilationResult .~ toProto co
 
-instance IsMessage P.CompilerFailure CompilerFailure where
+instance IsMessage P.CompilerFailure CompilerError where
   fromProto cf = do
     case cf ^. P.maybe'failure of
       Just (P.CompilerFailure'KcErr f) -> KCErr <$> fromProto f

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
@@ -11,9 +11,8 @@ import LambdaBuffers.Compiler.ProtoCompat.Types as X
 import Control.Lens (Getter, to, (&), (.~), (^.))
 import Data.Foldable (toList)
 import Data.Generics.Labels ()
-import Data.Generics.Product qualified as P
 import Data.Kind (Type)
-import Data.List.NonEmpty (fromList, nonEmpty)
+import Data.List.NonEmpty (nonEmpty)
 import Data.Map qualified as M
 import Data.ProtoLens (defMessage)
 import Data.Text (Text)

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
@@ -513,63 +513,63 @@ instance IsMessage P.KindCheckError KindCheckError where
   fromProto kce =
     case kce ^. P.maybe'kindCheckError of
       Just x -> case x of
-        P.KindCheckError'UnboundTermErr err ->
-          UnboundTermErr
+        P.KindCheckError'UnboundTermError' err ->
+          UnboundTermError
             <$> fromProto (err ^. P.tyName)
             <*> fromProto (err ^. P.varName)
-        P.KindCheckError'UnificationErr err ->
+        P.KindCheckError'UnificationError err ->
           IncorrectApplicationError
             <$> fromProto (err ^. P.tyName)
             <*> fromProto (err ^. P.tyKind1)
             <*> fromProto (err ^. P.tyKind2)
-        P.KindCheckError'RecursiveSubsErr err ->
+        P.KindCheckError'RecursiveSubsError err ->
           RecursiveKindError
             <$> fromProto (err ^. P.tyName)
-        P.KindCheckError'InconsistentTypeErr err ->
-          InconsistentTypeErr
+        P.KindCheckError'InconsistentTypeError' err ->
+          InconsistentTypeError
             <$> fromProto (err ^. P.tyName)
             <*> fromProto (err ^. P.inferredKind)
             <*> fromProto (err ^. P.definedKind)
       Nothing -> throwProtoError EmptyField
 
   toProto = \case
-    UnboundTermErr tyname varname ->
+    UnboundTermError tyname varname ->
       defMessage
-        & (P.unboundTermErr . P.tyName) .~ toProto tyname
-        & (P.unboundTermErr . P.varName) .~ toProto varname
+        & (P.unboundTermError . P.tyName) .~ toProto tyname
+        & (P.unboundTermError . P.varName) .~ toProto varname
     IncorrectApplicationError name k1 k2 ->
       defMessage
-        & (P.unificationErr . P.tyName) .~ toProto name
-        & (P.unificationErr . P.tyKind1) .~ toProto k1
-        & (P.unificationErr . P.tyKind2) .~ toProto k2
+        & (P.unificationError . P.tyName) .~ toProto name
+        & (P.unificationError . P.tyKind1) .~ toProto k1
+        & (P.unificationError . P.tyKind2) .~ toProto k2
     RecursiveKindError err ->
       defMessage
-        & (P.recursiveSubsErr . P.tyName) .~ toProto err
-    InconsistentTypeErr name ki kd ->
+        & (P.recursiveSubsError . P.tyName) .~ toProto err
+    InconsistentTypeError name ki kd ->
       defMessage
-        & (P.inconsistentTypeErr . P.tyName) .~ toProto name
-        & (P.inconsistentTypeErr . P.inferredKind) .~ toProto ki
-        & (P.inconsistentTypeErr . P.definedKind) .~ toProto kd
+        & (P.inconsistentTypeError . P.tyName) .~ toProto name
+        & (P.inconsistentTypeError . P.inferredKind) .~ toProto ki
+        & (P.inconsistentTypeError . P.definedKind) .~ toProto kd
 
 instance IsMessage P.InternalError MiscError where
   fromProto kce = case kce ^. P.maybe'internalError of
     Just x -> case x of
-      P.InternalError'ImpossibleError' err -> ImpossibleErr <$> fromProto (err ^. P.msg)
+      P.InternalError'ImpossibleError' err -> ImpossibleError <$> fromProto (err ^. P.msg)
     Nothing -> throwProtoError EmptyField
 
   toProto = \case
-    ImpossibleErr err -> defMessage & (P.impossibleError . P.msg) .~ toProto err
+    ImpossibleError err -> defMessage & (P.impossibleError . P.msg) .~ toProto err
 
 instance IsMessage P.CompilerError CompilerError where
   fromProto err = case err ^. P.maybe'compilerError of
     Just x -> case x of
-      P.CompilerError'CompKindCheckErr kcerr -> CompKindCheckError <$> fromProto kcerr
-      P.CompilerError'CompMiscErr miscerr -> CompMiscError <$> fromProto miscerr
+      P.CompilerError'CompKindCheckError kcerr -> CompKindCheckError <$> fromProto kcerr
+      P.CompilerError'CompMiscError miscerr -> CompMiscError <$> fromProto miscerr
     Nothing -> throwProtoError EmptyField
 
   toProto = \case
-    CompKindCheckError kcerr -> defMessage & P.compKindCheckErr .~ toProto kcerr
-    CompMiscError miscerr -> defMessage & P.compMiscErr .~ toProto miscerr
+    CompKindCheckError kcerr -> defMessage & P.compKindCheckError .~ toProto kcerr
+    CompMiscError miscerr -> defMessage & P.compMiscError .~ toProto miscerr
 
 instance IsMessage P.CompilerResult CompilerResult where
   fromProto c =

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedLabels #-}
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
@@ -551,25 +550,16 @@ instance IsMessage P.KindCheckError KindCheckError where
         & (P.inconsistentTypeError . P.inferredKind) .~ toProto ki
         & (P.inconsistentTypeError . P.definedKind) .~ toProto kd
 
-instance IsMessage P.InternalError MiscError where
-  fromProto kce = case kce ^. P.maybe'internalError of
-    Just x -> case x of
-      P.InternalError'ImpossibleError' err -> ImpossibleError <$> fromProto (err ^. P.msg)
-    Nothing -> throwProtoError EmptyField
-
-  toProto = \case
-    ImpossibleError err -> defMessage & (P.impossibleError . P.msg) .~ toProto err
-
 instance IsMessage P.CompilerError CompilerError where
-  fromProto err = case err ^. P.maybe'compilerError of
+  fromProto cErr = case cErr ^. P.maybe'compilerError of
     Just x -> case x of
-      P.CompilerError'CompKindCheckError kcerr -> CompKindCheckError <$> fromProto kcerr
-      P.CompilerError'CompMiscError miscerr -> CompMiscError <$> fromProto miscerr
+      P.CompilerError'KindCheckError err -> CompKindCheckError <$> fromProto err
+      P.CompilerError'InternalError err -> InternalError <$> fromProto (err ^. P.internalError)
     Nothing -> throwProtoError EmptyField
 
   toProto = \case
-    CompKindCheckError kcerr -> defMessage & P.compKindCheckError .~ toProto kcerr
-    CompMiscError miscerr -> defMessage & P.compMiscError .~ toProto miscerr
+    CompKindCheckError err -> defMessage & P.kindCheckError .~ toProto err
+    InternalError err -> defMessage & (P.internalError . P.internalError) .~ toProto err
 
 instance IsMessage P.CompilerResult CompilerResult where
   fromProto c =

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -2,6 +2,7 @@
 
 module LambdaBuffers.Compiler.ProtoCompat.Types (
   ClassDef (..),
+  MiscError (..),
   ClassName (..),
   CompilerError (..),
   CompilerInput (..),
@@ -230,13 +231,13 @@ data KindCheckError
   = UnboundTermErr Text
   | UnificationErr Text
   | RecursiveSubstitutionErr Text
-  | InconsistentTypeErr TyDef
+  | InconsistentTypeErr TyRef
   deriving stock (Show, Eq, Ord, Generic)
 instance Exception KindCheckError
 
 data CompilerError
   = CompKindCheckError KindCheckError
-  | CompMiscErr MiscError
+  | CompMiscError MiscError
   deriving stock (Show, Eq, Ord, Generic)
 
 data ValidatedTyDef = ValidatedTyDef {tyRef :: TyRef, tyBody :: Ty, tyKind :: Kind}

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -3,7 +3,6 @@
 
 module LambdaBuffers.Compiler.ProtoCompat.Types (
   ClassDef (..),
-  MiscError (..),
   ClassName (..),
   CompilerError (..),
   CompilerInput (..),
@@ -219,10 +218,6 @@ newtype CompilerInput = CompilerInput {modules :: [Module]}
   deriving stock (Show, Eq, Ord, Generic)
   deriving newtype (Monoid, Semigroup)
 
-newtype MiscError = ImpossibleError Text
-  deriving stock (Show, Eq, Ord, Generic)
-instance Exception MiscError
-
 data KindCheckError
   = -- | The following term is unbound in the following type definition.
     UnboundTermError TyName VarName
@@ -237,7 +232,7 @@ instance Exception KindCheckError
 
 data CompilerError
   = CompKindCheckError KindCheckError
-  | CompMiscError MiscError
+  | InternalError Text
   deriving stock (Show, Eq, Ord, Generic)
 
 data CompilerResult = CompilerResult

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -42,6 +42,7 @@ module LambdaBuffers.Compiler.ProtoCompat.Types (
   VarName (..),
 ) where
 
+import Control.Exception (Exception)
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map qualified as M
 import Data.Text (Text)
@@ -223,10 +224,14 @@ data InferenceErr
   | RecursiveSubstitutionErr Text
   deriving stock (Show, Eq, Ord, Generic)
 
+instance Exception InferenceErr
+
 data KindCheckErr
   = InconsistentTypeErr TyDef
   | InferenceFailure TyDef InferenceErr
   deriving stock (Show, Eq, Ord, Generic)
+
+instance Exception KindCheckErr
 
 newtype CompilerInput = CompilerInput {modules :: [Module]}
   deriving stock (Show, Eq, Ord, Generic)

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -40,6 +40,7 @@ module LambdaBuffers.Compiler.ProtoCompat.Types (
   TyRef (..),
   TyVar (..),
   VarName (..),
+  module VARS,
 ) where
 
 import Control.Exception (Exception)
@@ -47,6 +48,7 @@ import Data.List.NonEmpty (NonEmpty)
 import Data.Map qualified as M
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import LambdaBuffers.Compiler.KindCheck.Variable as VARS (Atom, Var)
 
 data SourceInfo = SourceInfo {file :: Text, posFrom :: SourcePosition, posTo :: SourcePosition}
   deriving stock (Show, Eq, Ord, Generic)
@@ -79,7 +81,7 @@ data FieldName = FieldName {name :: Text, sourceInfo :: SourceInfo}
 data ClassName = ClassName {name :: Text, sourceInfo :: SourceInfo}
   deriving stock (Show, Eq, Ord, Generic)
 
-data Kind = Kind {kind :: KindType, sourceInfo :: SourceInfo}
+newtype Kind = Kind {kind :: KindType}
   deriving stock (Show, Eq, Ord, Generic)
 
 data KindType
@@ -238,7 +240,7 @@ newtype CompilerInput = CompilerInput {modules :: [Module]}
   deriving newtype (Monoid, Semigroup)
 
 newtype CompilerOutput = CompilerOutput
-  { typeDefs :: M.Map TyDef Kind
+  { typeDefs :: M.Map Var Kind
   }
   deriving stock (Show, Eq, Ord, Generic)
 

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -220,19 +220,19 @@ newtype CompilerInput = CompilerInput {modules :: [Module]}
   deriving stock (Show, Eq, Ord, Generic)
   deriving newtype (Monoid, Semigroup)
 
-newtype MiscError = ImpossibleErr Text
+newtype MiscError = ImpossibleError Text
   deriving stock (Show, Eq, Ord, Generic)
 instance Exception MiscError
 
 data KindCheckError
   = -- | The following term is unbound in the following type definition.
-    UnboundTermErr TyName VarName
+    UnboundTermError TyName VarName
   | -- | Failed unifying TyRef with TyRef in TyName. This is the TyDef.
     IncorrectApplicationError TyName Kind Kind
   | -- | Kind recurses forever - not permitted.
     RecursiveKindError TyName
   | -- | The following type has the wrong.
-    InconsistentTypeErr TyName Kind Kind
+    InconsistentTypeError TyName Kind Kind
   deriving stock (Show, Eq, Ord, Generic)
 instance Exception KindCheckError
 

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -240,10 +240,7 @@ data CompilerError
   | CompMiscError MiscError
   deriving stock (Show, Eq, Ord, Generic)
 
-data ValidatedTyDef = ValidatedTyDef {tyRef :: TyRef, tyBody :: Ty, tyKind :: Kind}
-  deriving stock (Show, Eq, Ord, Generic)
-
-newtype CompilerResult = CompilerResult {typeDefs :: M.Map TyRef (Ty, Kind)}
+data CompilerResult = CompilerResult
   deriving stock (Show, Eq, Ord, Generic)
 
 type CompilerOutput = Either CompilerError CompilerResult

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -1,57 +1,56 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 
 module LambdaBuffers.Compiler.ProtoCompat.Types (
-  SourceInfo (..),
-  SourcePosition (..),
-  LBName (..),
-  TyName (..),
+  ClassDef (..),
+  ClassName (..),
+  CompilerFailure (..),
+  CompilerInput (..),
+  CompilerOutput (..),
+  CompilerResult (..),
   ConstrName (..),
+  Constraint (..),
+  Constructor (..),
+  Field (..),
+  FieldName (..),
+  ForeignRef (..),
+  InferenceErr (..),
+  InstanceClause (..),
+  Kind (..),
+  KindRefType (..),
+  KindCheckErr (..),
+  KindType (..),
+  LBName (..),
+  LocalRef (..),
+  Module (..),
   ModuleName (..),
   ModuleNamePart (..),
-  VarName (..),
-  FieldName (..),
-  ClassName (..),
-  Kind (..),
-  KindType (..),
-  KindRefType (..),
-  TyVar (..),
+  Product (..),
+  Record (..),
+  SourceInfo (..),
+  SourcePosition (..),
+  Sum (..),
+  Tuple (..),
   Ty (..),
-  TyApp (..),
-  ForeignRef (..),
-  LocalRef (..),
-  TyRef (..),
-  TyDef (..),
   TyAbs (..),
+  TyApp (..),
   TyArg (..),
   TyBody (..),
-  Constructor (..),
-  Sum (..),
-  Field (..),
-  Record (..),
-  Tuple (..),
-  Product (..),
-  ClassDef (..),
-  InstanceClause (..),
-  Constraint (..),
-  Module (..),
-  CompilerInput (..),
+  TyDef (..),
+  TyName (..),
+  TyRef (..),
+  TyVar (..),
+  VarName (..),
 ) where
 
 import Data.List.NonEmpty (NonEmpty)
+import Data.Map qualified as M
 import Data.Text (Text)
 import GHC.Generics (Generic)
 
-data SourceInfo = SourceInfo
-  { file :: Text
-  , posFrom :: SourcePosition
-  , posTo :: SourcePosition
-  }
+data SourceInfo = SourceInfo {file :: Text, posFrom :: SourcePosition, posTo :: SourcePosition}
   deriving stock (Show, Eq, Ord, Generic)
 
-data SourcePosition = SourcePosition
-  { column :: Int
-  , row :: Int
-  }
+data SourcePosition = SourcePosition {column :: Int, row :: Int}
   deriving stock (Show, Eq, Ord, Generic)
 
 -- NOTE(gnumonik): I need a "generic name" type for my template haskell, this shouldn't be used anywhere outside of that
@@ -217,6 +216,31 @@ data Module = Module
   }
   deriving stock (Show, Eq, Ord, Generic)
 
+data InferenceErr
+  = UnboundTermErr Text
+  | ImpossibleErr Text
+  | UnificationErr Text
+  | RecursiveSubstitutionErr Text
+  deriving stock (Show, Eq, Ord, Generic)
+
+data KindCheckErr
+  = InconsistentTypeErr TyDef
+  | InferenceFailure TyDef InferenceErr
+  deriving stock (Show, Eq, Ord, Generic)
+
 newtype CompilerInput = CompilerInput {modules :: [Module]}
   deriving stock (Show, Eq, Ord, Generic)
   deriving newtype (Monoid, Semigroup)
+
+newtype CompilerOutput = CompilerOutput
+  { typeDefs :: M.Map TyDef Kind
+  }
+  deriving stock (Show, Eq, Ord, Generic)
+
+newtype CompilerFailure = KCErr KindCheckErr
+  deriving stock (Show, Eq, Ord, Generic)
+
+data CompilerResult
+  = RCompilerFailure CompilerFailure
+  | RCompilerOutput CompilerOutput
+  deriving stock (Show, Eq, Ord, Generic)

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# OPTIONS_GHC -Wno-missing-import-lists #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 module LambdaBuffers.Compiler.ProtoCompat.Types (

--- a/lambda-buffers-compiler/test/Test/KindCheck.hs
+++ b/lambda-buffers-compiler/test/Test/KindCheck.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -Wno-missing-signatures #-}
-
 module Test.KindCheck (test) where
 
 import Data.List.NonEmpty (NonEmpty ((:|)), cons)
@@ -20,16 +18,20 @@ test = testGroup "Compiler tests" [testCheck, testFolds]
 --------------------------------------------------------------------------------
 -- Module tests
 
+testCheck :: TestTree
 testCheck = testGroup "KindChecker Tests" [trivialKCTest, kcTestMaybe, kcTestFailing]
 
+trivialKCTest :: TestTree
 trivialKCTest =
   testCase "Empty CompInput should check." $
     check_ (P.CompilerInput []) @?= Right ()
 
+kcTestMaybe :: TestTree
 kcTestMaybe =
   testCase "Maybe should pass." $
     check_ compilerInput'maybe @?= Right ()
 
+kcTestFailing :: TestTree
 kcTestFailing =
   testCase "This should fail." $
     assertBool "Test should have failed." $
@@ -38,6 +40,7 @@ kcTestFailing =
 --------------------------------------------------------------------------------
 -- Fold tests
 
+testFolds :: TestTree
 testFolds =
   testGroup
     "Test Folds"
@@ -46,17 +49,20 @@ testFolds =
     ]
 
 -- | [ a ] -> a
+testFoldProd1 :: TestTree
 testFoldProd1 =
   testCase "Fold with product - 1 type." $
     foldWithProduct (Var "a" :| []) @?= Var "a"
 
 -- | [a ,b] -> (a,b)
+testFoldProd2 :: TestTree
 testFoldProd2 =
   testCase "Fold with product - 2 types." $
     foldWithProduct (cons (Var "b") $ Var "a" :| [])
       @?= App (App (Var "Π") (Var "b")) (Var "a")
 
 -- | [ a, b ,c ] -> (a,(b,c))
+testFoldProd3 :: TestTree
 testFoldProd3 =
   testCase "Fold with product - 2 types." $
     foldWithProduct (cons (Var "c") $ cons (Var "b") $ Var "a" :| [])
@@ -65,17 +71,20 @@ testFoldProd3 =
         (App (App (Var "Π") (Var "b")) (Var "a"))
 
 -- | [ a ] -> a
+testSumFold1 :: TestTree
 testSumFold1 =
   testCase "Fold 1 type." $
     foldWithSum (Var "a" :| []) @?= Var "a"
 
 -- | [ a , b ] -> a | b
+testSumFold2 :: TestTree
 testSumFold2 =
   testCase "Fold 2 type." $
     foldWithSum (cons (Var "b") $ Var "a" :| [])
       @?= App (App (Var "Σ") (Var "b")) (Var "a")
 
 -- | [ a , b , c ] -> a | ( b | c )
+testSumFold3 :: TestTree
 testSumFold3 =
   testCase "Fold 3 types." $
     foldWithSum (cons (Var "c") $ cons (Var "b") $ Var "a" :| [])

--- a/lambda-buffers-compiler/test/Test/KindCheck.hs
+++ b/lambda-buffers-compiler/test/Test/KindCheck.hs
@@ -10,7 +10,7 @@ import LambdaBuffers.Compiler.KindCheck (
  )
 import LambdaBuffers.Compiler.KindCheck.Type (Type (App, Var))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
-import Test.Samples (ci1, ci2)
+import Test.Samples (compilerInput'incoherent, compilerInput'maybe)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase, (@?=))
 
@@ -28,12 +28,12 @@ trivialKCTest =
 
 kcTestMaybe =
   testCase "Maybe should pass." $
-    check_ ci1 @?= Right ()
+    check_ compilerInput'maybe @?= Right ()
 
 kcTestFailing =
   testCase "This should fail." $
     assertBool "Test should have failed." $
-      check_ ci2 /= Right ()
+      check_ compilerInput'incoherent /= Right ()
 
 --------------------------------------------------------------------------------
 -- Fold tests

--- a/lambda-buffers-compiler/test/Test/KindCheck.hs
+++ b/lambda-buffers-compiler/test/Test/KindCheck.hs
@@ -1,14 +1,23 @@
 module Test.KindCheck (test) where
 
 import Data.List.NonEmpty (NonEmpty ((:|)), cons)
+import Data.Text (Text)
 import LambdaBuffers.Compiler.KindCheck (
   check_,
   foldWithProduct,
   foldWithSum,
  )
 import LambdaBuffers.Compiler.KindCheck.Type (Type (App, Var))
-import LambdaBuffers.Compiler.ProtoCompat qualified as P
-import Test.Samples (compilerInput'incoherent, compilerInput'maybe)
+import LambdaBuffers.Compiler.KindCheck.Variable (
+  Variable (LocalRef),
+ )
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P (
+  CompilerInput (CompilerInput),
+ )
+import Test.Samples.Proto.CompilerInput (
+  compilerInput'incoherent,
+  compilerInput'maybe,
+ )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase, (@?=))
 
@@ -52,42 +61,46 @@ testFolds =
 testFoldProd1 :: TestTree
 testFoldProd1 =
   testCase "Fold with product - 1 type." $
-    foldWithProduct (Var "a" :| []) @?= Var "a"
+    foldWithProduct (lVar "a" :| []) @?= lVar "a"
 
 -- | [a ,b] -> (a,b)
 testFoldProd2 :: TestTree
 testFoldProd2 =
   testCase "Fold with product - 2 types." $
-    foldWithProduct (cons (Var "b") $ Var "a" :| [])
-      @?= App (App (Var "Π") (Var "b")) (Var "a")
+    foldWithProduct (cons (lVar "b") $ lVar "a" :| [])
+      @?= App (App (lVar "Π") (lVar "b")) (lVar "a")
 
 -- | [ a, b ,c ] -> (a,(b,c))
 testFoldProd3 :: TestTree
 testFoldProd3 =
   testCase "Fold with product - 2 types." $
-    foldWithProduct (cons (Var "c") $ cons (Var "b") $ Var "a" :| [])
+    foldWithProduct (cons (lVar "c") $ cons (lVar "b") $ lVar "a" :| [])
       @?= App
-        (App (Var "Π") (Var "c"))
-        (App (App (Var "Π") (Var "b")) (Var "a"))
+        (App (lVar "Π") (lVar "c"))
+        (App (App (lVar "Π") (lVar "b")) (lVar "a"))
 
 -- | [ a ] -> a
 testSumFold1 :: TestTree
 testSumFold1 =
   testCase "Fold 1 type." $
-    foldWithSum (Var "a" :| []) @?= Var "a"
+    foldWithSum (lVar "a" :| []) @?= lVar "a"
 
 -- | [ a , b ] -> a | b
 testSumFold2 :: TestTree
 testSumFold2 =
   testCase "Fold 2 type." $
-    foldWithSum (cons (Var "b") $ Var "a" :| [])
-      @?= App (App (Var "Σ") (Var "b")) (Var "a")
+    foldWithSum (cons (lVar "b") $ lVar "a" :| [])
+      @?= App (App (lVar "Σ") (lVar "b")) (lVar "a")
 
 -- | [ a , b , c ] -> a | ( b | c )
 testSumFold3 :: TestTree
 testSumFold3 =
   testCase "Fold 3 types." $
-    foldWithSum (cons (Var "c") $ cons (Var "b") $ Var "a" :| [])
+    foldWithSum (cons (lVar "c") $ cons (lVar "b") $ lVar "a" :| [])
       @?= App
-        (App (Var "Σ") (Var "c"))
-        (App (App (Var "Σ") (Var "b")) (Var "a"))
+        (App (lVar "Σ") (lVar "c"))
+        (App (App (lVar "Σ") (lVar "b")) (lVar "a"))
+
+-- | TyDef to Kind Canonical representation - sums not folded - therefore we get constructor granularity. Might use in a different implementation for more granular errors.
+lVar :: Text -> Type
+lVar = Var . LocalRef

--- a/lambda-buffers-compiler/test/Test/KindCheck.hs
+++ b/lambda-buffers-compiler/test/Test/KindCheck.hs
@@ -57,7 +57,7 @@ modMaybe =
                           , P.argKind =
                               P.Kind
                                 { P.kind = P.KindRef P.KType
-                                , P.sourceInfo = esi
+                                -- , P.sourceInfo = esi
                                 }
                           , P.sourceInfo = esi
                           }
@@ -129,7 +129,7 @@ ci2 = ci1 & #modules .~ [addMod]
                                   , P.argKind =
                                       P.Kind
                                         { P.kind = P.KindRef P.KType
-                                        , P.sourceInfo = esi
+                                        -- , P.sourceInfo = esi
                                         }
                                   , P.sourceInfo = esi
                                   }

--- a/lambda-buffers-compiler/test/Test/KindCheck.hs
+++ b/lambda-buffers-compiler/test/Test/KindCheck.hs
@@ -7,7 +7,7 @@ module Test.KindCheck (test) where
 import Control.Lens ((%~), (&), (.~))
 import Data.List.NonEmpty (NonEmpty ((:|)), cons)
 import LambdaBuffers.Compiler.KindCheck (
-  check,
+  check_,
   foldWithProduct,
   foldWithSum,
  )
@@ -26,16 +26,16 @@ testCheck = testGroup "KindChecker Tests" [trivialKCTest, kcTestMaybe, kcTestFai
 
 trivialKCTest =
   testCase "Empty CompInput should check." $
-    check (P.CompilerInput []) @?= Right ()
+    check_ (P.CompilerInput []) @?= Right ()
 
 kcTestMaybe =
   testCase "Maybe should pass." $
-    check ci1 @?= Right ()
+    check_ ci1 @?= Right ()
 
 kcTestFailing =
   testCase "This should fail." $
     assertBool "Test should have failed." $
-      check ci2 /= Right ()
+      check_ ci2 /= Right ()
 
 esi = P.SourceInfo "Empty Info" (P.SourcePosition 0 0) (P.SourcePosition 0 1)
 

--- a/lambda-buffers-compiler/test/Test/Samples.hs
+++ b/lambda-buffers-compiler/test/Test/Samples.hs
@@ -1,3 +1,5 @@
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
 module Test.Samples (module M) where
 
 import Test.Samples.Proto.CompilerInput as M

--- a/lambda-buffers-compiler/test/Test/Samples.hs
+++ b/lambda-buffers-compiler/test/Test/Samples.hs
@@ -1,0 +1,5 @@
+module Test.Samples (module M) where
+
+import Test.Samples.Proto.CompilerInput as M
+import Test.Samples.Proto.Module as M
+import Test.Samples.Proto.SourceInfo as M

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/CompilerInput.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/CompilerInput.hs
@@ -1,0 +1,15 @@
+{-# OPTIONS_GHC -Wno-missing-import-lists #-}
+
+module Test.Samples.Proto.CompilerInput where
+
+import Control.Lens ((&), (.~))
+import LambdaBuffers.Compiler.ProtoCompat qualified as P
+import Test.Samples.Proto.Module
+
+-- | Compiler Input containing 1 module with 1 definition - Maybe.
+ci1 :: P.CompilerInput
+ci1 = P.CompilerInput {P.modules = [modMaybe]}
+
+-- | Contains 2 definitions - 1 wrong one.
+ci2 :: P.CompilerInput
+ci2 = ci1 & #modules .~ [addMod]

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/CompilerInput.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/CompilerInput.hs
@@ -7,9 +7,9 @@ import LambdaBuffers.Compiler.ProtoCompat qualified as P
 import Test.Samples.Proto.Module
 
 -- | Compiler Input containing 1 module with 1 definition - Maybe.
-ci1 :: P.CompilerInput
-ci1 = P.CompilerInput {P.modules = [modMaybe]}
+compilerInput'maybe :: P.CompilerInput
+compilerInput'maybe = P.CompilerInput {P.modules = [module'maybe]}
 
 -- | Contains 2 definitions - 1 wrong one.
-ci2 :: P.CompilerInput
-ci2 = ci1 & #modules .~ [addMod]
+compilerInput'incoherent :: P.CompilerInput
+compilerInput'incoherent = compilerInput'maybe & #modules .~ [module'incoherent]

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/CompilerInput.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/CompilerInput.hs
@@ -1,6 +1,4 @@
-{-# OPTIONS_GHC -Wno-missing-import-lists #-}
-
-module Test.Samples.Proto.CompilerInput where
+module Test.Samples.Proto.CompilerInput (compilerInput'incoherent, compilerInput'maybe) where
 
 import Control.Lens ((&), (.~))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/CompilerInput.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/CompilerInput.hs
@@ -4,7 +4,7 @@ module Test.Samples.Proto.CompilerInput where
 
 import Control.Lens ((&), (.~))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
-import Test.Samples.Proto.Module
+import Test.Samples.Proto.Module (module'incoherent, module'maybe)
 
 -- | Compiler Input containing 1 module with 1 definition - Maybe.
 compilerInput'maybe :: P.CompilerInput

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/Helpers.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/Helpers.hs
@@ -1,6 +1,20 @@
-module Test.Samples.Proto.Helpers where
+module Test.Samples.Proto.Helpers (
+  _tyName,
+  _varName,
+  _tyVar,
+  _TyVarI,
+  _TupleI,
+  _Constructor,
+  _ConstrName,
+  _Sum,
+  _TyAbs,
+  _TyArg,
+  _Type,
+  _TyDef,
+  _TyRefILocal,
+) where
 
-import Data.List.NonEmpty (NonEmpty ((:|)), fromList)
+import Data.List.NonEmpty (fromList)
 import Data.Text (Text)
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
 import Test.Samples.Proto.SourceInfo (sourceInfo'empty)

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/Helpers.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/Helpers.hs
@@ -39,10 +39,10 @@ _TupleI x =
       , P.sourceInfo = sourceInfo'empty
       }
 
-_Constructor :: P.ConstrName -> P.Product -> P.Constructor
+_Constructor :: Text -> P.Product -> P.Constructor
 _Constructor c f =
   P.Constructor
-    { P.constrName = c
+    { P.constrName = _ConstrName c
     , P.product = f
     }
 
@@ -53,19 +53,19 @@ _ConstrName x =
     , P.sourceInfo = sourceInfo'empty
     }
 
-_Sum :: [P.Constructor] -> P.TyBody
+_Sum :: [(Text, P.Product)] -> P.TyBody
 _Sum cs =
   P.SumI $
     P.Sum
-      { constructors = fromList cs
+      { constructors = fromList $ uncurry _Constructor <$> cs
       , sourceInfo = sourceInfo'empty
       }
 
-_TyAbs :: [P.TyArg] -> P.TyBody -> P.TyAbs
+_TyAbs :: [(Text, P.KindType)] -> [(Text, P.Product)] -> P.TyAbs
 _TyAbs args body =
   P.TyAbs
-    { P.tyArgs = args
-    , P.tyBody = body
+    { P.tyArgs = _TyArg <$> args
+    , P.tyBody = _Sum body
     , sourceInfo = sourceInfo'empty
     }
 

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/Helpers.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/Helpers.hs
@@ -1,0 +1,79 @@
+module Test.Samples.Proto.Helpers where
+
+import Data.List.NonEmpty (NonEmpty ((:|)), fromList)
+import Data.Text (Text)
+import LambdaBuffers.Compiler.ProtoCompat qualified as P
+import Test.Samples.Proto.SourceInfo (sourceInfo'empty)
+
+_tyName :: Text -> P.TyName
+_tyName x = P.TyName x sourceInfo'empty
+
+_varName :: Text -> P.VarName
+_varName x = P.VarName {P.name = x, P.sourceInfo = sourceInfo'empty}
+
+_tyVar :: Text -> P.TyVar
+_tyVar x = P.TyVar {P.varName = _varName x, P.sourceInfo = sourceInfo'empty}
+
+_TyVarI :: Text -> P.Ty
+_TyVarI x = P.TyVarI $ P.TyVar {P.varName = _varName x, P.sourceInfo = sourceInfo'empty}
+
+_TupleI :: [P.Ty] -> P.Product
+_TupleI x =
+  P.TupleI $
+    P.Tuple
+      { P.fields = x
+      , P.sourceInfo = sourceInfo'empty
+      }
+
+_Constructor :: P.ConstrName -> P.Product -> P.Constructor
+_Constructor c f =
+  P.Constructor
+    { P.constrName = c
+    , P.product = f
+    }
+
+_ConstrName :: Text -> P.ConstrName
+_ConstrName x =
+  P.ConstrName
+    { P.name = x
+    , P.sourceInfo = sourceInfo'empty
+    }
+
+_Sum :: [P.Constructor] -> P.TyBody
+_Sum cs =
+  P.SumI $
+    P.Sum
+      { constructors = fromList cs
+      , sourceInfo = sourceInfo'empty
+      }
+
+_TyAbs :: [P.TyArg] -> P.TyBody -> P.TyAbs
+_TyAbs args body =
+  P.TyAbs
+    { P.tyArgs = args
+    , P.tyBody = body
+    , sourceInfo = sourceInfo'empty
+    }
+
+_TyArg :: (Text, P.KindType) -> P.TyArg
+_TyArg (a, k) =
+  P.TyArg
+    { P.argName = P.VarName a sourceInfo'empty
+    , P.argKind = P.Kind {P.kind = k}
+    , P.sourceInfo = sourceInfo'empty
+    }
+
+_Type :: P.KindType
+_Type = P.KindRef P.KType
+
+_TyDef :: P.TyName -> P.TyAbs -> P.TyDef
+_TyDef name ab = P.TyDef {P.tyName = name, P.tyAbs = ab, sourceInfo = sourceInfo'empty}
+
+_TyRefILocal :: Text -> P.Ty
+_TyRefILocal x =
+  P.TyRefI $
+    P.LocalI $
+      P.LocalRef
+        { P.tyName = P.TyName {P.name = x, P.sourceInfo = sourceInfo'empty}
+        , P.sourceInfo = sourceInfo'empty
+        }

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/Module.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/Module.hs
@@ -2,8 +2,8 @@ module Test.Samples.Proto.Module where
 
 import Control.Lens ((%~), (&))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
-import Test.Samples.Proto.SourceInfo
-import Test.Samples.Proto.TyDef
+import Test.Samples.Proto.SourceInfo (sourceInfo'empty)
+import Test.Samples.Proto.TyDef (tyDef'incoherent, tyDef'maybe)
 
 module'maybe :: P.Module
 module'maybe =

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/Module.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/Module.hs
@@ -1,0 +1,130 @@
+module Test.Samples.Proto.Module where
+
+import Control.Lens ((%~), (&), (.~))
+import Data.List.NonEmpty (NonEmpty ((:|)), cons)
+import LambdaBuffers.Compiler.ProtoCompat qualified as P
+import Test.Samples.Proto.SourceInfo
+
+modMaybe =
+  P.Module
+    { P.moduleName =
+        P.ModuleName
+          { P.parts = [P.ModuleNamePart "Module" esi]
+          , P.sourceInfo = esi
+          }
+    , P.typeDefs =
+        [ P.TyDef
+            { P.tyName = P.TyName "Maybe" esi
+            , P.tyAbs =
+                P.TyAbs
+                  { P.tyArgs =
+                      [ P.TyArg
+                          { P.argName = P.VarName "a" esi
+                          , P.argKind =
+                              P.Kind
+                                { P.kind = P.KindRef P.KType
+                                -- , P.sourceInfo = esi
+                                }
+                          , P.sourceInfo = esi
+                          }
+                      ]
+                  , P.tyBody =
+                      P.SumI $
+                        P.Sum
+                          { constructors =
+                              P.Constructor
+                                { P.constrName = P.ConstrName {P.name = "Nothing", P.sourceInfo = esi}
+                                , P.product = P.TupleI $ P.Tuple {P.fields = [], P.sourceInfo = esi}
+                                }
+                                :| [ P.Constructor
+                                      { P.constrName = P.ConstrName {P.name = "Just", P.sourceInfo = esi}
+                                      , P.product =
+                                          P.TupleI $
+                                            P.Tuple
+                                              { P.fields =
+                                                  [ P.TyVarI
+                                                      ( P.TyVar
+                                                          { P.varName =
+                                                              P.VarName
+                                                                { P.name = "a"
+                                                                , P.sourceInfo = esi
+                                                                }
+                                                          , P.sourceInfo = esi
+                                                          }
+                                                      )
+                                                  ]
+                                              , P.sourceInfo = esi
+                                              }
+                                      }
+                                   ]
+                          , sourceInfo = esi
+                          }
+                  , P.sourceInfo = esi
+                  }
+            , P.sourceInfo = esi
+            }
+        ]
+    , P.classDefs = mempty
+    , P.instances = mempty
+    , P.sourceInfo = esi
+    }
+
+{- | 1 Module containing
+  Maybe = ...
+
+  and adding:
+  B a = B Maybe
+
+ Should fail as B a defaults to B :: Type -> Type and Maybe is inferred as
+ Type -> Type. This is an inconsistency failure.
+-}
+addMod :: P.Module
+addMod =
+  modMaybe
+    & #typeDefs
+      %~ ( <>
+            [ -- B a = B Maybe
+              P.TyDef
+                { P.tyName = P.TyName "B" esi
+                , P.tyAbs =
+                    P.TyAbs
+                      { P.tyArgs =
+                          [ P.TyArg
+                              { P.argName = P.VarName "a" esi
+                              , P.argKind =
+                                  P.Kind
+                                    { P.kind = P.KindRef P.KType
+                                    -- , P.sourceInfo = esi
+                                    }
+                              , P.sourceInfo = esi
+                              }
+                          ]
+                      , P.tyBody =
+                          P.SumI $
+                            P.Sum
+                              { constructors =
+                                  P.Constructor
+                                    { P.constrName = P.ConstrName {P.name = "B", P.sourceInfo = esi}
+                                    , P.product =
+                                        P.TupleI $
+                                          P.Tuple
+                                            { P.fields =
+                                                [ P.TyRefI $
+                                                    P.LocalI $
+                                                      P.LocalRef
+                                                        { P.tyName = P.TyName {P.name = "Maybe", P.sourceInfo = esi}
+                                                        , P.sourceInfo = esi
+                                                        }
+                                                ]
+                                            , P.sourceInfo = esi
+                                            }
+                                    }
+                                    :| []
+                              , sourceInfo = esi
+                              }
+                      , P.sourceInfo = esi
+                      }
+                , P.sourceInfo = esi
+                }
+            ]
+         )

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/Module.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/Module.hs
@@ -1,4 +1,4 @@
-module Test.Samples.Proto.Module where
+module Test.Samples.Proto.Module (module'maybe, module'incoherent) where
 
 import Control.Lens ((%~), (&))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/Module.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/Module.hs
@@ -1,72 +1,22 @@
 module Test.Samples.Proto.Module where
 
-import Control.Lens ((%~), (&), (.~))
-import Data.List.NonEmpty (NonEmpty ((:|)), cons)
+import Control.Lens ((%~), (&))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
 import Test.Samples.Proto.SourceInfo
+import Test.Samples.Proto.TyDef
 
-modMaybe =
+module'maybe :: P.Module
+module'maybe =
   P.Module
     { P.moduleName =
         P.ModuleName
-          { P.parts = [P.ModuleNamePart "Module" esi]
-          , P.sourceInfo = esi
+          { P.parts = [P.ModuleNamePart "Module" sourceInfo'empty]
+          , P.sourceInfo = sourceInfo'empty
           }
-    , P.typeDefs =
-        [ P.TyDef
-            { P.tyName = P.TyName "Maybe" esi
-            , P.tyAbs =
-                P.TyAbs
-                  { P.tyArgs =
-                      [ P.TyArg
-                          { P.argName = P.VarName "a" esi
-                          , P.argKind =
-                              P.Kind
-                                { P.kind = P.KindRef P.KType
-                                -- , P.sourceInfo = esi
-                                }
-                          , P.sourceInfo = esi
-                          }
-                      ]
-                  , P.tyBody =
-                      P.SumI $
-                        P.Sum
-                          { constructors =
-                              P.Constructor
-                                { P.constrName = P.ConstrName {P.name = "Nothing", P.sourceInfo = esi}
-                                , P.product = P.TupleI $ P.Tuple {P.fields = [], P.sourceInfo = esi}
-                                }
-                                :| [ P.Constructor
-                                      { P.constrName = P.ConstrName {P.name = "Just", P.sourceInfo = esi}
-                                      , P.product =
-                                          P.TupleI $
-                                            P.Tuple
-                                              { P.fields =
-                                                  [ P.TyVarI
-                                                      ( P.TyVar
-                                                          { P.varName =
-                                                              P.VarName
-                                                                { P.name = "a"
-                                                                , P.sourceInfo = esi
-                                                                }
-                                                          , P.sourceInfo = esi
-                                                          }
-                                                      )
-                                                  ]
-                                              , P.sourceInfo = esi
-                                              }
-                                      }
-                                   ]
-                          , sourceInfo = esi
-                          }
-                  , P.sourceInfo = esi
-                  }
-            , P.sourceInfo = esi
-            }
-        ]
+    , P.typeDefs = [tyDef'maybe]
     , P.classDefs = mempty
     , P.instances = mempty
-    , P.sourceInfo = esi
+    , P.sourceInfo = sourceInfo'empty
     }
 
 {- | 1 Module containing
@@ -78,53 +28,5 @@ modMaybe =
  Should fail as B a defaults to B :: Type -> Type and Maybe is inferred as
  Type -> Type. This is an inconsistency failure.
 -}
-addMod :: P.Module
-addMod =
-  modMaybe
-    & #typeDefs
-      %~ ( <>
-            [ -- B a = B Maybe
-              P.TyDef
-                { P.tyName = P.TyName "B" esi
-                , P.tyAbs =
-                    P.TyAbs
-                      { P.tyArgs =
-                          [ P.TyArg
-                              { P.argName = P.VarName "a" esi
-                              , P.argKind =
-                                  P.Kind
-                                    { P.kind = P.KindRef P.KType
-                                    -- , P.sourceInfo = esi
-                                    }
-                              , P.sourceInfo = esi
-                              }
-                          ]
-                      , P.tyBody =
-                          P.SumI $
-                            P.Sum
-                              { constructors =
-                                  P.Constructor
-                                    { P.constrName = P.ConstrName {P.name = "B", P.sourceInfo = esi}
-                                    , P.product =
-                                        P.TupleI $
-                                          P.Tuple
-                                            { P.fields =
-                                                [ P.TyRefI $
-                                                    P.LocalI $
-                                                      P.LocalRef
-                                                        { P.tyName = P.TyName {P.name = "Maybe", P.sourceInfo = esi}
-                                                        , P.sourceInfo = esi
-                                                        }
-                                                ]
-                                            , P.sourceInfo = esi
-                                            }
-                                    }
-                                    :| []
-                              , sourceInfo = esi
-                              }
-                      , P.sourceInfo = esi
-                      }
-                , P.sourceInfo = esi
-                }
-            ]
-         )
+module'incoherent :: P.Module
+module'incoherent = module'maybe & #typeDefs %~ (<> [tyDef'incoherent])

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/SourceInfo.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/SourceInfo.hs
@@ -1,0 +1,6 @@
+module Test.Samples.Proto.SourceInfo where
+
+import LambdaBuffers.Compiler.ProtoCompat qualified as P
+
+-- | Empty Source Info
+esi = P.SourceInfo "Empty Info" (P.SourcePosition 0 0) (P.SourcePosition 0 1)

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/SourceInfo.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/SourceInfo.hs
@@ -1,4 +1,4 @@
-module Test.Samples.Proto.SourceInfo where
+module Test.Samples.Proto.SourceInfo (sourceInfo'empty) where
 
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
 

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/SourceInfo.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/SourceInfo.hs
@@ -3,4 +3,5 @@ module Test.Samples.Proto.SourceInfo where
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
 
 -- | Empty Source Info
+sourceInfo'empty :: P.SourceInfo
 sourceInfo'empty = P.SourceInfo "Empty Info" (P.SourcePosition 0 0) (P.SourcePosition 0 1)

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/SourceInfo.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/SourceInfo.hs
@@ -3,4 +3,4 @@ module Test.Samples.Proto.SourceInfo where
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
 
 -- | Empty Source Info
-esi = P.SourceInfo "Empty Info" (P.SourcePosition 0 0) (P.SourcePosition 0 1)
+sourceInfo'empty = P.SourceInfo "Empty Info" (P.SourcePosition 0 0) (P.SourcePosition 0 1)

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
@@ -1,9 +1,8 @@
 module Test.Samples.Proto.TyDef where
 
-import Control.Lens ((%~), (&), (.~))
-import Data.List.NonEmpty (NonEmpty ((:|)), cons)
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
-import Test.Samples.Proto.SourceInfo
+import Test.Samples.Proto.SourceInfo (sourceInfo'empty)
 
 -- | Maybe tyDef.
 tyDef'maybe :: P.TyDef
@@ -71,7 +70,6 @@ tyDef'incoherent =
                   , P.argKind =
                       P.Kind
                         { P.kind = P.KindRef P.KType
-                        -- , P.sourceInfo = sourceInfo'empty
                         }
                   , P.sourceInfo = sourceInfo'empty
                   }

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
@@ -1,4 +1,4 @@
-module Test.Samples.Proto.TyDef where
+module Test.Samples.Proto.TyDef (tyDef'maybe, tyDef'incoherent) where
 
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
@@ -1,103 +1,40 @@
 module Test.Samples.Proto.TyDef (tyDef'maybe, tyDef'incoherent) where
 
-import Data.List.NonEmpty (NonEmpty ((:|)))
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
-import Test.Samples.Proto.SourceInfo (sourceInfo'empty)
+import Test.Samples.Proto.Helpers (
+  _ConstrName,
+  _Constructor,
+  _Sum,
+  _TupleI,
+  _TyAbs,
+  _TyArg,
+  _TyDef,
+  _TyRefILocal,
+  _TyVarI,
+  _Type,
+  _tyName,
+ )
 
 -- | Maybe tyDef.
 tyDef'maybe :: P.TyDef
 tyDef'maybe =
-  P.TyDef
-    { P.tyName = P.TyName "Maybe" sourceInfo'empty
-    , P.tyAbs =
-        P.TyAbs
-          { P.tyArgs =
-              [ P.TyArg
-                  { P.argName = P.VarName "a" sourceInfo'empty
-                  , P.argKind =
-                      P.Kind
-                        { P.kind = P.KindRef P.KType
-                        }
-                  , P.sourceInfo = sourceInfo'empty
-                  }
-              ]
-          , P.tyBody =
-              P.SumI $
-                P.Sum
-                  { constructors =
-                      P.Constructor
-                        { P.constrName = P.ConstrName {P.name = "Nothing", P.sourceInfo = sourceInfo'empty}
-                        , P.product = P.TupleI $ P.Tuple {P.fields = [], P.sourceInfo = sourceInfo'empty}
-                        }
-                        :| [ P.Constructor
-                              { P.constrName = P.ConstrName {P.name = "Just", P.sourceInfo = sourceInfo'empty}
-                              , P.product =
-                                  P.TupleI $
-                                    P.Tuple
-                                      { P.fields =
-                                          [ P.TyVarI
-                                              ( P.TyVar
-                                                  { P.varName =
-                                                      P.VarName
-                                                        { P.name = "a"
-                                                        , P.sourceInfo = sourceInfo'empty
-                                                        }
-                                                  , P.sourceInfo = sourceInfo'empty
-                                                  }
-                                              )
-                                          ]
-                                      , P.sourceInfo = sourceInfo'empty
-                                      }
-                              }
-                           ]
-                  , sourceInfo = sourceInfo'empty
-                  }
-          , P.sourceInfo = sourceInfo'empty
-          }
-    , P.sourceInfo = sourceInfo'empty
-    }
+  _TyDef
+    (_tyName "Maybe")
+    ( _TyAbs [_TyArg ("a", _Type)] $
+        _Sum
+          [ _Constructor (_ConstrName "Nothing") (_TupleI [])
+          , _Constructor (_ConstrName "Just") (_TupleI [_TyVarI "a"])
+          ]
+    )
 
 -- | B a = B Maybe
 tyDef'incoherent :: P.TyDef
 tyDef'incoherent =
-  P.TyDef
-    { P.tyName = P.TyName "B" sourceInfo'empty
-    , P.tyAbs =
-        P.TyAbs
-          { P.tyArgs =
-              [ P.TyArg
-                  { P.argName = P.VarName "a" sourceInfo'empty
-                  , P.argKind =
-                      P.Kind
-                        { P.kind = P.KindRef P.KType
-                        }
-                  , P.sourceInfo = sourceInfo'empty
-                  }
-              ]
-          , P.tyBody =
-              P.SumI $
-                P.Sum
-                  { constructors =
-                      P.Constructor
-                        { P.constrName = P.ConstrName {P.name = "B", P.sourceInfo = sourceInfo'empty}
-                        , P.product =
-                            P.TupleI $
-                              P.Tuple
-                                { P.fields =
-                                    [ P.TyRefI $
-                                        P.LocalI $
-                                          P.LocalRef
-                                            { P.tyName = P.TyName {P.name = "Maybe", P.sourceInfo = sourceInfo'empty}
-                                            , P.sourceInfo = sourceInfo'empty
-                                            }
-                                    ]
-                                , P.sourceInfo = sourceInfo'empty
-                                }
-                        }
-                        :| []
-                  , sourceInfo = sourceInfo'empty
-                  }
-          , P.sourceInfo = sourceInfo'empty
-          }
-    , P.sourceInfo = sourceInfo'empty
-    }
+  _TyDef
+    (_tyName "B")
+    ( _TyAbs [_TyArg ("a", _Type)] $
+        _Sum
+          [ _Constructor (_ConstrName "Nothing") (_TupleI [])
+          , _Constructor (_ConstrName "B") (_TupleI [_TyRefILocal "Maybe"])
+          ]
+    )

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
@@ -2,12 +2,8 @@ module Test.Samples.Proto.TyDef (tyDef'maybe, tyDef'incoherent) where
 
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
 import Test.Samples.Proto.Helpers (
-  _ConstrName,
-  _Constructor,
-  _Sum,
   _TupleI,
   _TyAbs,
-  _TyArg,
   _TyDef,
   _TyRefILocal,
   _TyVarI,
@@ -20,11 +16,11 @@ tyDef'maybe :: P.TyDef
 tyDef'maybe =
   _TyDef
     (_tyName "Maybe")
-    ( _TyAbs [_TyArg ("a", _Type)] $
-        _Sum
-          [ _Constructor (_ConstrName "Nothing") (_TupleI [])
-          , _Constructor (_ConstrName "Just") (_TupleI [_TyVarI "a"])
-          ]
+    ( _TyAbs
+        [("a", _Type)]
+        [ ("Nothing", _TupleI [])
+        , ("Just", _TupleI [_TyVarI "a"])
+        ]
     )
 
 -- | B a = B Maybe
@@ -32,9 +28,9 @@ tyDef'incoherent :: P.TyDef
 tyDef'incoherent =
   _TyDef
     (_tyName "B")
-    ( _TyAbs [_TyArg ("a", _Type)] $
-        _Sum
-          [ _Constructor (_ConstrName "Nothing") (_TupleI [])
-          , _Constructor (_ConstrName "B") (_TupleI [_TyRefILocal "Maybe"])
-          ]
+    ( _TyAbs
+        [("a", _Type)]
+        [ ("Nothing", _TupleI [])
+        , ("B", _TupleI [_TyRefILocal "Maybe"])
+        ]
     )

--- a/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
+++ b/lambda-buffers-compiler/test/Test/Samples/Proto/TyDef.hs
@@ -1,0 +1,105 @@
+module Test.Samples.Proto.TyDef where
+
+import Control.Lens ((%~), (&), (.~))
+import Data.List.NonEmpty (NonEmpty ((:|)), cons)
+import LambdaBuffers.Compiler.ProtoCompat qualified as P
+import Test.Samples.Proto.SourceInfo
+
+-- | Maybe tyDef.
+tyDef'maybe :: P.TyDef
+tyDef'maybe =
+  P.TyDef
+    { P.tyName = P.TyName "Maybe" sourceInfo'empty
+    , P.tyAbs =
+        P.TyAbs
+          { P.tyArgs =
+              [ P.TyArg
+                  { P.argName = P.VarName "a" sourceInfo'empty
+                  , P.argKind =
+                      P.Kind
+                        { P.kind = P.KindRef P.KType
+                        }
+                  , P.sourceInfo = sourceInfo'empty
+                  }
+              ]
+          , P.tyBody =
+              P.SumI $
+                P.Sum
+                  { constructors =
+                      P.Constructor
+                        { P.constrName = P.ConstrName {P.name = "Nothing", P.sourceInfo = sourceInfo'empty}
+                        , P.product = P.TupleI $ P.Tuple {P.fields = [], P.sourceInfo = sourceInfo'empty}
+                        }
+                        :| [ P.Constructor
+                              { P.constrName = P.ConstrName {P.name = "Just", P.sourceInfo = sourceInfo'empty}
+                              , P.product =
+                                  P.TupleI $
+                                    P.Tuple
+                                      { P.fields =
+                                          [ P.TyVarI
+                                              ( P.TyVar
+                                                  { P.varName =
+                                                      P.VarName
+                                                        { P.name = "a"
+                                                        , P.sourceInfo = sourceInfo'empty
+                                                        }
+                                                  , P.sourceInfo = sourceInfo'empty
+                                                  }
+                                              )
+                                          ]
+                                      , P.sourceInfo = sourceInfo'empty
+                                      }
+                              }
+                           ]
+                  , sourceInfo = sourceInfo'empty
+                  }
+          , P.sourceInfo = sourceInfo'empty
+          }
+    , P.sourceInfo = sourceInfo'empty
+    }
+
+-- | B a = B Maybe
+tyDef'incoherent :: P.TyDef
+tyDef'incoherent =
+  P.TyDef
+    { P.tyName = P.TyName "B" sourceInfo'empty
+    , P.tyAbs =
+        P.TyAbs
+          { P.tyArgs =
+              [ P.TyArg
+                  { P.argName = P.VarName "a" sourceInfo'empty
+                  , P.argKind =
+                      P.Kind
+                        { P.kind = P.KindRef P.KType
+                        -- , P.sourceInfo = sourceInfo'empty
+                        }
+                  , P.sourceInfo = sourceInfo'empty
+                  }
+              ]
+          , P.tyBody =
+              P.SumI $
+                P.Sum
+                  { constructors =
+                      P.Constructor
+                        { P.constrName = P.ConstrName {P.name = "B", P.sourceInfo = sourceInfo'empty}
+                        , P.product =
+                            P.TupleI $
+                              P.Tuple
+                                { P.fields =
+                                    [ P.TyRefI $
+                                        P.LocalI $
+                                          P.LocalRef
+                                            { P.tyName = P.TyName {P.name = "Maybe", P.sourceInfo = sourceInfo'empty}
+                                            , P.sourceInfo = sourceInfo'empty
+                                            }
+                                    ]
+                                , P.sourceInfo = sourceInfo'empty
+                                }
+                        }
+                        :| []
+                  , sourceInfo = sourceInfo'empty
+                  }
+          , P.sourceInfo = sourceInfo'empty
+          }
+    , P.sourceInfo = sourceInfo'empty
+    }

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -535,7 +535,7 @@ message KindCheckError {
   // FIXME(cstml): add source of constraint to the error such that user can see 
   // where the constraint was generated - therefore where the error precisely 
   // is. 
-  message IncorrectApplicationError {
+  message ImpossibleUnificationError {
     TyName ty_name = 1;
     Kind ty_kind_1 = 2;
     Kind ty_kind_2 = 3;
@@ -556,10 +556,10 @@ message KindCheckError {
 
   // The types of inference errors.
   oneof kind_check_error {
-    UnboundTermError unbound_term_err = 1;
-    IncorrectApplicationError unification_err = 2;
-    RecursiveKindError recursive_subs_err = 3; 
-    InconsistentTypeError inconsistent_type_err = 4;
+    UnboundTermError unbound_term_error = 1;
+    ImpossibleUnificationError unification_error = 2;
+    RecursiveKindError recursive_subs_error = 3; 
+    InconsistentTypeError inconsistent_type_error = 4;
   }
 }
 
@@ -568,8 +568,8 @@ message CompilerError {
   
   // Reason why the compilation failed.
   oneof compiler_error {
-    KindCheckError comp_kind_check_err = 1;
-    InternalError comp_misc_err = 2;
+    KindCheckError comp_kind_check_error = 1;
+    InternalError comp_misc_error = 2;
   }
 }
 

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -561,17 +561,9 @@ message CompilerError {
   }
 }
 
-// A validated type definition.
-message ValidatedTyDef {
-  TyRef ty_ref = 1 ;
-  Ty ty_body = 2;
-  Kind ty_kind = 3;
-}
-
 // Compiler Result ~ a successful Compilation Output.
 message CompilerResult {
-  // A map of checked type definitions.
-  repeated ValidatedTyDef type_defs = 1;
+  // equivalent of unit.
 }
 
 // Output of the Compiler.

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -490,14 +490,12 @@ message CompilerInput {
   repeated Module modules = 1;
 }
 
-
 // Compiler Failure can be extended with other classes of errors.
 message CompilerFailure {
   // Reason why the compilation failed.
   oneof failure {
     KindCheckErr kc_err = 1;
   }
-
 }
 
 /* Inference Failure 
@@ -580,7 +578,6 @@ message CompilerOutput {
   // A map of checked type definitions.
   repeated TypeDefinition type_defs = 1;
 }
-
 
 /* Compilation Result 
 

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -9,26 +9,12 @@ Frontends are advised to include *Source* information to denote how their
 *Compiler* errors back to the Frontend.
 */
 message SourceInfo {
-  
-  // // Information related to where the 
-  // message Generated {
-  //   string description = 1;
-  // }
-
-  // Source information relating to where the information is coming from.
-  // message Parsed {
   // A filename denoting the Source file.
   string file = 1;
   // Starting position in Source.
   SourcePosition pos_from = 2;
   // End position in Source.
   SourcePosition pos_to = 3;
-  // }
-
-  // oneof source_info {
-  //   Generated generated_info = 1;
-  //   Parsed parsed_info = 2; 
-  // }
 }
 
 /* Position in Source */

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -276,8 +276,6 @@ message Kind {
     KindRef kind_ref = 1;
     KindArrow kind_arrow = 2;
   };
-  // Source information.
-  SourceInfo source_info = 3;
 }
 
 
@@ -562,9 +560,14 @@ message KindCheckErr {
   }
 }
 
+// A namespaced type term.
+message NSTypeName {
+  string namespaced_name = 1;
+}
+
 // A validated type definition.
 message TypeDefinition {
-  TyDef type_def = 1 ;
+  NSTypeName ns_name = 1 ;
   Kind kind = 2;
 }
 

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -539,14 +539,15 @@ message KindCheckError {
   
   // The inferred type differs from the type as defined.
   message InconsistentTypeError {
-    TyDef type_def = 1;
+    TyRef ty_ref = 1;
   }
 
   // The types of inference errors.
-  oneof kindchek_error {
-    UnboundTermError unbound_term_e = 1;
-    UnificationError unification_e = 2;
-    RecursiveSubstitutionError recursive_subs_e = 3; 
+  oneof kind_check_error {
+    UnboundTermError unbound_term_err = 1;
+    UnificationError unification_err = 2;
+    RecursiveSubstitutionError recursive_subs_err = 3; 
+    InconsistentTypeError inconsistent_type_err = 4;
   }
 }
 
@@ -555,8 +556,8 @@ message CompilerError {
   
   // Reason why the compilation failed.
   oneof compiler_error {
-    KindCheckError kind_check_err = 1;
-    MiscError misc_err = 2;
+    KindCheckError comp_kind_check_err = 1;
+    MiscError comp_misc_err = 2;
   }
 }
 

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -491,3 +491,104 @@ message CompilerInput {
   // Modules to compile.
   repeated Module modules = 1;
 }
+
+
+message CompilerFailure {
+
+  // Source information relating to the error. 
+  SourceInfo source_info = 1;
+  
+  // Reason why the compilation failed.
+  oneof failure {
+    KindCheckErr kc_err = 2;
+  }
+
+}
+
+/* Inference Failure 
+ */
+
+message InferenceErr {
+
+  // Error referring to an unbound term. This usually means that the term was
+  // not defined.
+  message UnboundTerm {
+    string msg = 1; 
+  }
+
+  // This should never happen.
+  message ImpossibleErr {
+    string msg = 1;
+  }
+
+  // Unification has failed - type is incorrectly defined.
+  message UnificationErr {
+    string msg = 1; 
+  }
+
+  // Infinite recursion due to a substitution replacing a term with a term
+  // containing itself. Should never type check.
+  message RecursiveSubstitutionErr {
+    string msg = 1;
+  }
+
+  // The types of inference errors.
+  oneof inference_err {
+    UnboundTermErr unbound_term_err = 1;
+    ImpossibleErr impossible_err = 2;
+    UnificationErr unification_err = 3;
+    RecursiveSubstitutionErr recursive_subs_err = 4; 
+  }
+}
+
+/* Kindcheck Failure
+
+   Information regarding a Kindcheck failure.
+ */
+
+message KindCheckErr {
+
+  // The inferred type differs from the type as defined.
+  message InconsistentType {
+    TyDef type_def = 1;
+  }
+
+  message InferenceFailure {
+    TyDef type_def = 1;
+    InferenceErr infer_err = 2;
+  }
+  
+  oneof kind_check_error {
+    string err = 1;
+    InconsistentType inconsistent_type_err = 2; 
+  }
+}
+
+/*
+  Compiler Output
+
+  A successful Compilation Output.
+ */
+message CompilerOutput {
+  
+  // A type definition.
+  message TypeDefinition {
+    TyDef type_def = 1 ;
+    Kind kind = 2;
+  }
+  
+  // A map of checked type definitions.
+  repeated TypeDefinition type_defs = 1;
+}
+
+
+/* Compilation Result 
+
+   Compiler Output is either an Error or a Compiler Output.
+ */
+message CompilerResult {
+  oneof compiler_result {
+    CompilerFailure failed_compilation = 1;
+    CompilerOutput compilation_result = 2;
+  }
+}

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -493,14 +493,11 @@ message CompilerInput {
 }
 
 
+// Compiler Failure can be extended with other classes of errors.
 message CompilerFailure {
-
-  // Source information relating to the error. 
-  SourceInfo source_info = 1;
-  
   // Reason why the compilation failed.
   oneof failure {
-    KindCheckErr kc_err = 2;
+    KindCheckErr kc_err = 1;
   }
 
 }
@@ -533,35 +530,42 @@ message InferenceErr {
   }
 
   // The types of inference errors.
-  oneof inference_err {
-    UnboundTermErr unbound_term_err = 1;
-    ImpossibleErr impossible_err = 2;
-    UnificationErr unification_err = 3;
-    RecursiveSubstitutionErr recursive_subs_err = 4; 
+  oneof inf_err {
+    UnboundTermErr unbound_term_e = 1;
+    ImpossibleErr impossible_e = 2;
+    UnificationErr unification_e = 3;
+    RecursiveSubstitutionErr recursive_subs_e = 4; 
   }
 }
+
+// The inferred type differs from the type as defined.
+message InconsistentTypeErr {
+  TyDef type_def = 1;
+}
+
+// Inference failed.
+message InferenceFailure {
+  TyDef type_def = 1;
+  InferenceErr infer_err = 2;
+}
+
 
 /* Kindcheck Failure
 
    Information regarding a Kindcheck failure.
  */
-
 message KindCheckErr {
 
-  // The inferred type differs from the type as defined.
-  message InconsistentType {
-    TyDef type_def = 1;
-  }
-
-  message InferenceFailure {
-    TyDef type_def = 1;
-    InferenceErr infer_err = 2;
-  }
-  
   oneof kind_check_error {
-    string err = 1;
-    InconsistentType inconsistent_type_err = 2; 
+    InferenceFailure inference_failure_err = 1;
+    InconsistentTypeErr inconsistent_type_err = 2; 
   }
+}
+
+// A validated type definition.
+message TypeDefinition {
+  TyDef type_def = 1 ;
+  Kind kind = 2;
 }
 
 /*
@@ -570,13 +574,6 @@ message KindCheckErr {
   A successful Compilation Output.
  */
 message CompilerOutput {
-  
-  // A type definition.
-  message TypeDefinition {
-    TyDef type_def = 1 ;
-    Kind kind = 2;
-  }
-  
   // A map of checked type definitions.
   repeated TypeDefinition type_defs = 1;
 }
@@ -591,4 +588,5 @@ message CompilerResult {
     CompilerFailure failed_compilation = 1;
     CompilerOutput compilation_result = 2;
   }
+  SourceInfo source_info = 3;
 }

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -9,12 +9,26 @@ Frontends are advised to include *Source* information to denote how their
 *Compiler* errors back to the Frontend.
 */
 message SourceInfo {
+  
+  // // Information related to where the 
+  // message Generated {
+  //   string description = 1;
+  // }
+
+  // Source information relating to where the information is coming from.
+  // message Parsed {
   // A filename denoting the Source file.
   string file = 1;
   // Starting position in Source.
   SourcePosition pos_from = 2;
   // End position in Source.
   SourcePosition pos_to = 3;
+  // }
+
+  // oneof source_info {
+  //   Generated generated_info = 1;
+  //   Parsed parsed_info = 2; 
+  // }
 }
 
 /* Position in Source */
@@ -490,103 +504,79 @@ message CompilerInput {
   repeated Module modules = 1;
 }
 
-// Compiler Failure can be extended with other classes of errors.
-message CompilerFailure {
-  // Reason why the compilation failed.
-  oneof failure {
-    KindCheckErr kc_err = 1;
-  }
-}
-
-/* Inference Failure 
- */
-
-message InferenceErr {
-
-  // Error referring to an unbound term. This usually means that the term was
-  // not defined.
-  message UnboundTermErr {
-    string msg = 1; 
-  }
+// Miscellaneous errors.
+message MiscError {
 
   // This should never happen.
-  message ImpossibleErr {
+  message ImpossibleError {
     string msg = 1;
   }
 
+  oneof misc_error {
+    ImpossibleError impossible_error = 1;
+  }
+}
+
+// Kindchecker errors.
+message KindCheckError {
+
+  // Error referring to an unbound term. This usually means that the term was
+  // not defined.
+  message UnboundTermError {
+    string msg = 1; 
+  }
+
   // Unification has failed - type is incorrectly defined.
-  message UnificationErr {
+  message UnificationError {
     string msg = 1; 
   }
 
   // Infinite recursion due to a substitution replacing a term with a term
   // containing itself. Should never type check.
-  message RecursiveSubstitutionErr {
+  message RecursiveSubstitutionError {
     string msg = 1;
+  }
+  
+  // The inferred type differs from the type as defined.
+  message InconsistentTypeError {
+    TyDef type_def = 1;
   }
 
   // The types of inference errors.
-  oneof inf_err {
-    UnboundTermErr unbound_term_e = 1;
-    ImpossibleErr impossible_e = 2;
-    UnificationErr unification_e = 3;
-    RecursiveSubstitutionErr recursive_subs_e = 4; 
+  oneof kindchek_error {
+    UnboundTermError unbound_term_e = 1;
+    UnificationError unification_e = 2;
+    RecursiveSubstitutionError recursive_subs_e = 3; 
   }
 }
 
-// The inferred type differs from the type as defined.
-message InconsistentTypeErr {
-  TyDef type_def = 1;
-}
-
-// Inference failed.
-message InferenceFailure {
-  TyDef type_def = 1;
-  InferenceErr infer_err = 2;
-}
-
-
-/* Kindcheck Failure
-
-   Information regarding a Kindcheck failure.
- */
-message KindCheckErr {
-
-  oneof kind_check_error {
-    InferenceFailure inference_failure_err = 1;
-    InconsistentTypeErr inconsistent_type_err = 2; 
+// Compiler Error can be extended with other classes of errors.
+message CompilerError {
+  
+  // Reason why the compilation failed.
+  oneof compiler_error {
+    KindCheckError kind_check_err = 1;
+    MiscError misc_err = 2;
   }
-}
-
-// A namespaced type term.
-message NSTypeName {
-  string namespaced_name = 1;
 }
 
 // A validated type definition.
-message TypeDefinition {
-  NSTypeName ns_name = 1 ;
-  Kind kind = 2;
+message ValidatedTyDef {
+  TyRef ty_ref = 1 ;
+  Ty ty_body = 2;
+  Kind ty_kind = 3;
 }
 
-/*
-  Compiler Output
-
-  A successful Compilation Output.
- */
-message CompilerOutput {
-  // A map of checked type definitions.
-  repeated TypeDefinition type_defs = 1;
-}
-
-/* Compilation Result 
-
-   Compiler Output is either an Error or a Compiler Output.
- */
+// Compiler Result ~ a successful Compilation Output.
 message CompilerResult {
-  oneof compiler_result {
-    CompilerFailure failed_compilation = 1;
-    CompilerOutput compilation_result = 2;
+  // A map of checked type definitions.
+  repeated ValidatedTyDef type_defs = 1;
+}
+
+// Output of the Compiler.
+message CompilerOutput {
+  oneof compiler_output {
+    CompilerError compilation_error = 1;
+    CompilerResult compilation_result = 2;
   }
-  SourceInfo source_info = 3;
 }

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -512,7 +512,7 @@ message InferenceErr {
 
   // Error referring to an unbound term. This usually means that the term was
   // not defined.
-  message UnboundTerm {
+  message UnboundTermErr {
     string msg = 1; 
   }
 

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -492,15 +492,7 @@ message CompilerInput {
 
 // Internal errors.
 message InternalError {
-
-  // This should never happen.
-  message ImpossibleError {
-    string msg = 1;
-  }
-
-  oneof internal_error {
-    ImpossibleError impossible_error = 1;
-  }
+  string internal_error = 1;
 }
 
 // Kindchecker errors.
@@ -554,8 +546,8 @@ message CompilerError {
   
   // Reason why the compilation failed.
   oneof compiler_error {
-    KindCheckError comp_kind_check_error = 1;
-    InternalError comp_misc_error = 2;
+    KindCheckError kind_check_error = 1;
+    InternalError internal_error = 2;
   }
 }
 

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -504,15 +504,15 @@ message CompilerInput {
   repeated Module modules = 1;
 }
 
-// Miscellaneous errors.
-message MiscError {
+// Internal errors.
+message InternalError {
 
   // This should never happen.
   message ImpossibleError {
     string msg = 1;
   }
 
-  oneof misc_error {
+  oneof internal_error {
     ImpossibleError impossible_error = 1;
   }
 }
@@ -523,30 +523,42 @@ message KindCheckError {
   // Error referring to an unbound term. This usually means that the term was
   // not defined.
   message UnboundTermError {
-    string msg = 1; 
+    TyName ty_name = 1;
+    VarName var_name = 2;
   }
 
-  // Unification has failed - type is incorrectly defined.
-  message UnificationError {
-    string msg = 1; 
+  // Unification has failed - type is incorrectly defined. Error reads as 
+  // follows:
+  // > In ty_name definition an error has occurred when trying to unify kind 
+  // > ty_kind_1 with ty_kind_2. 
+  //
+  // FIXME(cstml): add source of constraint to the error such that user can see 
+  // where the constraint was generated - therefore where the error precisely 
+  // is. 
+  message IncorrectApplicationError {
+    TyName ty_name = 1;
+    Kind ty_kind_1 = 2;
+    Kind ty_kind_2 = 3;
   }
 
-  // Infinite recursion due to a substitution replacing a term with a term
-  // containing itself. Should never type check.
-  message RecursiveSubstitutionError {
-    string msg = 1;
+  // Error reads:
+  // Inifinitely recursive term detected in definition ty_name. 
+  message RecursiveKindError {
+    TyName ty_name = 1;
   }
   
   // The inferred type differs from the type as defined.
   message InconsistentTypeError {
-    TyRef ty_ref = 1;
+    TyName ty_name = 1;
+    Kind inferred_kind = 2;
+    Kind defined_kind = 3;
   }
 
   // The types of inference errors.
   oneof kind_check_error {
     UnboundTermError unbound_term_err = 1;
-    UnificationError unification_err = 2;
-    RecursiveSubstitutionError recursive_subs_err = 3; 
+    IncorrectApplicationError unification_err = 2;
+    RecursiveKindError recursive_subs_err = 3; 
     InconsistentTypeError inconsistent_type_err = 4;
   }
 }
@@ -557,7 +569,7 @@ message CompilerError {
   // Reason why the compilation failed.
   oneof compiler_error {
     KindCheckError comp_kind_check_err = 1;
-    MiscError comp_misc_err = 2;
+    InternalError comp_misc_err = 2;
   }
 }
 


### PR DESCRIPTION
- hook up the Kind Checker to the CLI too.
- propose error types.
- propose Compiler output format.
- tidy up some of the things used in the test into their own modules.