### PR TITLE
compiler/typeclass-solver

### DIFF
--- a/lambda-buffers-compiler/lambda-buffers-compiler.cabal
+++ b/lambda-buffers-compiler/lambda-buffers-compiler.cabal
@@ -117,6 +117,7 @@ library
     LambdaBuffers.Compiler.TypeClass.Pat
     LambdaBuffers.Compiler.TypeClass.Pretty
     LambdaBuffers.Compiler.TypeClass.Rules
+    LambdaBuffers.Compiler.TypeClass.Solve
     LambdaBuffers.Compiler.TypeClassCheck
 
   hs-source-dirs:  src

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Pat.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Pat.hs
@@ -19,10 +19,14 @@ cost of significantly more complex type signatures.
 -}
 
 data Pat
-  = {- extremely stupid, unfortunately necessary -}
+  = {- Name / ModuleName / Opaque / TyVarP are literal patterns (or ground terms)
+       because hey cannot contain any VarPs and therefore "have no holes".
+       Every TyDef or subcomponent thereof will be translated into a composite
+       pattern "without any holes". (Nil is also a literal/ground term, I guess) -}
     Name Text
-  | ModuleName [Text] -- also stupid, also necessary -_-
+  | ModuleName [Text]
   | Opaque
+  | TyVarP Text
   | {- Lists (constructed from Nil and :*) with bare types are used to
        encode products (where a list of length n encodes an n-tuple)
        Lists with field labels (l := t) are used to encode records and sum types
@@ -45,10 +49,8 @@ data Pat
   | ProdP Pat {- Pat arg should be a list of "Bare types" -}
   | SumP Pat {- where the Pat arg is expected to be (Constr l t :* rest) or Nil, where
                 rest is either Nil or a tyList of Constrs -}
-  | VarP Text {- This isn't a type variable. Although it is used to represent them in certain contexts,
-                 it is also used more generally to refer to any "hole" in a pattern to which another pattern
-                 may be substituted. We could have separate constr for type variables but it doesn't appear to be
-                 necessary at this time. -}
+  | VarP Text {- This isn't a type variable. It is used more generally to refer to any "hole" in a pattern into
+                 to which another pattern may be substituted. TyVarP is the literal pattern / ground term for TyVars  -}
   | RefP Pat Pat {- 1st arg should be a ModuleName  -}
   | AppP Pat Pat {- Pattern for Type applications -}
   | {- This last one is a bit special. This represents a complete type declaration.

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Pretty.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Pretty.hs
@@ -10,8 +10,9 @@ module LambdaBuffers.Compiler.TypeClass.Pretty (
 ) where
 
 import Data.Generics.Labels ()
+import Data.Text qualified as T
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
-import LambdaBuffers.Compiler.TypeClass.Pat (Pat (AppP, DecP, ModuleName, Name, Nil, Opaque, ProdP, RecP, RefP, SumP, VarP, (:*), (:=)), patList)
+import LambdaBuffers.Compiler.TypeClass.Pat (Pat (AppP, DecP, ModuleName, Name, Nil, Opaque, ProdP, RecP, RefP, SumP, TyVarP, VarP, (:*), (:=)), patList)
 import LambdaBuffers.Compiler.TypeClass.Rules (
   Class (Class),
   Constraint (C),
@@ -58,6 +59,7 @@ instance Pretty Pat where
     Name t -> pretty t
     ModuleName ts -> hcat . punctuate "." . map pretty $ ts
     Opaque -> "<OPAQUE>"
+    TyVarP t -> pretty t
     RecP ps -> case patList ps of
       Nothing -> pretty ps
       Just fields -> case traverse prettyField fields of
@@ -80,7 +82,8 @@ instance Pretty Pat where
     RefP mn@(ModuleName _) n@(Name _) -> pretty mn <> "." <> pretty n
     RefP Nil (Name n) -> pretty n
     RefP p1 p2 -> parens $ "Ref" <+> pretty p1 <+> pretty p2
-    VarP t -> pretty t
+    -- Pattern variables are uppercased to distinguish them from proper TyVars
+    VarP t -> pretty (T.toUpper t)
     ap@(AppP p1 p2) -> case prettyApp ap of
       Just pap -> parens pap
       Nothing -> "App" <+> pretty p1 <+> pretty p2

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Pretty.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Pretty.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedLabels #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- orphans are the whole point of this module!
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -10,14 +9,13 @@ module LambdaBuffers.Compiler.TypeClass.Pretty (
   (<///>),
 ) where
 
-import Control.Lens ((^.))
 import Data.Generics.Labels ()
 import LambdaBuffers.Compiler.ProtoCompat qualified as P
 import LambdaBuffers.Compiler.TypeClass.Pat (Pat (AppP, DecP, ModuleName, Name, Nil, Opaque, ProdP, RecP, RefP, SumP, VarP, (:*), (:=)), patList)
 import LambdaBuffers.Compiler.TypeClass.Rules (
   Class (Class),
   Constraint (C),
-  Instance,
+  FQClassName (FQClassName),
   Rule ((:<=)),
  )
 import Prettyprinter (
@@ -34,13 +32,8 @@ import Prettyprinter (
   (<+>),
  )
 
-instance Pretty P.TyClassRef where
-  pretty = \case
-    P.ForeignCI (P.ForeignClassRef cn mn _) -> pretty mn <> "." <> pretty (cn ^. #name)
-    P.LocalCI (P.LocalClassRef cn _) -> pretty (cn ^. #name)
-
-instance Pretty P.ModuleName where
-  pretty (P.ModuleName pts _) = hcat . punctuate "." $ map (\x -> pretty $ x ^. #name) pts
+instance Pretty FQClassName where
+  pretty (FQClassName cn mnps) = hcat (punctuate "." . map pretty $ mnps) <> pretty cn
 
 instance Pretty Class where
   pretty (Class nm _) = pretty nm
@@ -48,7 +41,7 @@ instance Pretty Class where
 instance Pretty Constraint where
   pretty (C cls p) = pretty cls <+> pretty p
 
-instance Pretty Instance where
+instance Pretty Rule where
   pretty (c :<= []) = pretty c
   pretty (c :<= cs) = pretty c <+> "<=" <+> list (pretty <$> cs)
 

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Rules.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Rules.hs
@@ -5,16 +5,22 @@ module LambdaBuffers.Compiler.TypeClass.Rules (
   Class (..),
   Constraint (..),
   Rule (..),
-  type Instance,
+  FQClassName (..),
   mapPat,
+  ruleHeadPat,
+  ruleHeadClass,
 ) where
 
-import LambdaBuffers.Compiler.ProtoCompat qualified as P
+import Data.Text (Text)
+
 import LambdaBuffers.Compiler.TypeClass.Pat (Pat)
 
+data FQClassName = FQClassName {cName :: Text, cModule :: [Text]}
+  deriving stock (Show, Eq, Ord)
+
 data Class = Class
-  { name :: P.TyClassRef
-  , supers :: [Class]
+  { cname :: FQClassName
+  , csupers :: [Class]
   }
   deriving stock (Show, Eq, Ord)
 
@@ -33,9 +39,15 @@ data Rule where
   deriving stock (Show, Eq, Ord)
 infixl 7 :<=
 
-type Instance = Rule
-
 {- Map over the Pats inside of an Rule
 -}
 mapPat :: (Pat -> Pat) -> Rule -> Rule
 mapPat f (C c ty :<= is) = C c (f ty) :<= map (\(C cx p) -> C cx (f p)) is
+
+{- Extract the inner Pat from a Rule head
+-}
+ruleHeadPat :: Rule -> Pat
+ruleHeadPat (C _ p :<= _) = p
+
+ruleHeadClass :: Rule -> Class
+ruleHeadClass (C c _ :<= _) = c

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Solve.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClass/Solve.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE LambdaCase #-}
+
+module LambdaBuffers.Compiler.TypeClass.Solve (solve) where
+
+import Data.List (foldl', sortBy)
+import Data.Text (Text)
+import LambdaBuffers.Compiler.TypeClass.Pat (
+  Pat (AppP, DecP, ProdP, RecP, RefP, SumP, VarP, (:*), (:=)),
+  matches,
+ )
+import LambdaBuffers.Compiler.TypeClass.Rules (
+  Class (csupers),
+  Constraint (C),
+  Rule ((:<=)),
+  mapPat,
+  ruleHeadClass,
+  ruleHeadPat,
+ )
+
+import Data.Set qualified as S
+
+{- Variable substitution. Given a string that represents a variable name,
+   and a type to instantiate variables with that name to, performs the
+   instantiation
+-}
+subV :: Text -> Pat -> Pat -> Pat
+subV varNm t = \case
+  var@(VarP v) -> if v == varNm then t else var
+  x :* xs -> subV varNm t x :* subV varNm t xs
+  l := x -> subV varNm t l := subV varNm t x
+  ProdP xs -> ProdP (subV varNm t xs)
+  RecP xs -> RecP (subV varNm t xs)
+  SumP xs -> SumP (subV varNm t xs)
+  AppP t1 t2 -> AppP (subV varNm t t1) (subV varNm t t2)
+  RefP n x -> RefP (subV varNm t n) (subV varNm t x)
+  DecP a b c -> DecP (subV varNm t a) (subV varNm t b) (subV varNm t c)
+  other -> other
+
+{- Performs substitution on an entire instance (the first argument) given the
+   concrete types from a Pat (the second argument).
+   Note that ONLY PatVars which occur in the Instance *HEAD* are replaced, though they
+   are replaced in the instance superclasses as well (if they occur there).
+-}
+subst :: Rule -> Pat -> Rule
+subst cst@(C _ t :<= _) ty = mapPat (go (getSubs t ty)) cst
+  where
+    go :: [(Text, Pat)] -> Pat -> Pat
+    go subs tty =
+      let noflip p1 p2 = uncurry subV p2 p1
+       in foldl' noflip tty subs
+
+{- Given two patterns (which are hopefully structurally similar), gather a list of all substitutions
+   from the PatVars in the first argument to the concrete types (hopefully!) in the second argument
+-}
+getSubs :: Pat -> Pat -> [(Text, Pat)] -- should be a set, whatever
+getSubs (VarP s) t = [(s, t)]
+getSubs (x :* xs) (x' :* xs') = getSubs x x' <> getSubs xs xs'
+getSubs (l := t) (l' := t') = getSubs l l' <> getSubs t t'
+getSubs (ProdP xs) (ProdP xs') = getSubs xs xs'
+getSubs (RecP xs) (RecP xs') = getSubs xs xs'
+getSubs (SumP xs) (SumP xs') = getSubs xs xs'
+getSubs (AppP t1 t2) (AppP t1' t2') = getSubs t1 t1' <> getSubs t2 t2'
+getSubs (RefP n t) (RefP n' t') = getSubs n n' <> getSubs t t'
+getSubs (DecP a b c) (DecP a' b' c') = getSubs a a' <> getSubs b b' <> getSubs c c'
+getSubs _ _ = []
+
+-- should be vastly more efficient than Data.List.Nub
+deduplicate :: Ord a => [a] -> [a]
+deduplicate = S.toList . S.fromList
+
+-- is the first pattern a substitution instance of the second
+isSubstitutionOf :: Pat -> Pat -> Bool
+isSubstitutionOf p1 p2 = matches p2 p1
+
+compareSpecificity :: Pat -> Pat -> Ordering
+compareSpecificity p1 p2
+  | p1
+      `isSubstitutionOf` p2
+      && p2
+      `isSubstitutionOf` p1 =
+      EQ
+  | p1 `isSubstitutionOf` p2 = LT
+  | otherwise = GT
+
+sortOnSpecificity :: Pat -> Class -> [Rule] -> [Rule]
+sortOnSpecificity p c ps =
+  sortBy (\a1 a2 -> compareSpecificity (ruleHeadPat a1) (ruleHeadPat a2)) $
+    filter matchPatAndClass ps
+  where
+    matchPatAndClass :: Rule -> Bool
+    matchPatAndClass r =
+      ruleHeadClass r == c
+        && ruleHeadPat r
+        `matches` p
+
+mostSpecificInstance :: Pat -> Class -> [Rule] -> Maybe Rule
+mostSpecificInstance p c ps = case sortOnSpecificity p c ps of
+  [] -> Nothing
+  (x : _) -> Just x
+
+{- Given a list of instances (the initial scope), determines whether we can derive
+   an instance of the Class argument for the Pat argument. A result of [] indicates that there are
+   no remaining subgoals and that the constraint has been solved.
+   NOTE: At the moment this handles superclasses differently than you might expect -
+         instead of assuming that the superclasses for all in-scope classes are defined,
+         we check that those constraints can be solved before affirmatively judging that the
+         target constraint has been solved. I *think* that makes sense in this context (whereas in Haskell
+         it doesn't b/c it's *impossible* to have `instance Foo X` if the definition of Foo is
+         `class Bar y => Foo y` without an `instance Bar X`)
+-}
+solve ::
+  [Rule] -> -- all instance rules in scope. WE ASSUME THESE HAVE ALREADY BEEN GENERATED, SOMEWHERE
+  Constraint -> -- constraint we're trying to solve
+  [Constraint] -- subgoals that cannot be solved for w/ the current rule set
+solve inScope cst@(C c pat) =
+  -- First, we look for the most specific instance...
+  case mostSpecificInstance pat c inScope of
+    -- If there isn't one, we return only the constraint we were trying to solve
+    Nothing -> [cst]
+    -- If there is, we substitute the argument of the constraint to be solved into the matching rules
+    Just rule -> case subst rule pat of
+      -- If there are no additional constraints on the rule, we try to solve the superclasses
+      C _ p :<= [] -> case csupers c of
+        [] -> []
+        xs -> solveClassesFor p xs
+      -- If there are additional constraints on the rule, we try to solve them
+      C _ _ :<= is -> case concatMap (solve inScope) is of
+        -- If we succeed at solving the additional constraints on the rule, we try to solve the supers
+        [] -> solveClassesFor pat (csupers c)
+        -- We deduplicate the list of unsolvable subgoals
+        xs -> deduplicate xs
+  where
+    -- NOTE(@bladyjoker): The version w/ flip is more performant...
+    -- Given a Pat and a list of Classes, attempt to solve the constraints
+    -- constructed from the Pat and each Class
+    solveClassesFor :: Pat -> [Class] -> [Constraint]
+    solveClassesFor p =
+      deduplicate -- multiple constraints could emit the same subgoal which is bad
+        . concatMap
+          ( solve inScope
+              . ( \cls ->
+                    let classConstraint = C cls p
+                     in classConstraint
+                )
+          )

--- a/lambda-buffers-compiler/test/Test/TypeClassCheck.hs
+++ b/lambda-buffers-compiler/test/Test/TypeClassCheck.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-module Test.TypeClassCheck (test) where
+module Test.TypeClassCheck {- (test) -} where
 
 import Control.Lens ((.~))
 import Data.Function ((&))
@@ -19,6 +19,7 @@ import LambdaBuffers.Compiler.TypeClass.Pat (
     RecP,
     RefP,
     SumP,
+    TyVarP,
     VarP,
     (:*),
     (:=)
@@ -31,7 +32,7 @@ import LambdaBuffers.Compiler.TypeClass.Rules (
   Rule ((:<=)),
  )
 import LambdaBuffers.Compiler.TypeClass.Rules qualified as R
-import LambdaBuffers.Compiler.TypeClass.Solve (solve)
+import LambdaBuffers.Compiler.TypeClass.Solve (Overlap (Overlap), solve)
 import LambdaBuffers.Compiler.TypeClassCheck (detectSuperclassCycles')
 import Proto.Compiler (ClassDef, Constraint, Kind, Kind'KindRef (Kind'KIND_REF_TYPE))
 import Proto.Compiler_Fields (argKind, argName, arguments, classArgs, className, classRef, kindRef, localClassRef, name, supers, tyVar, varName)
@@ -109,60 +110,77 @@ solveTests =
   testGroup
     "Solver tests"
     [ testCase "1: C [Maybe Int] (completeRules)" $
-        solveTest1 @?= []
+        solveTest1 @?= solved
     , testCase "2: D [Maybe Int] (partialRules)" $
-        solveTest2 @?= [dInt]
+        solveTest2 @?= Right [cListMaybeInt, cMaybeInt, dInt]
     , testCase "3: D [Maybe Int] (complete D, partial C)" $
-        solveTest3 @?= [cInt]
+        solveTest3 @?= Right [cInt]
     , testCase "4: C [[[Bool]]] (completeRules)" $
-        solveTest4 @?= []
+        solveTest4 @?= solved
     , testCase "5: C (Either (Either Int Bool) (Either Bool Int)) (completeRules)" $
-        solveTest5 @?= []
+        solveTest5 @?= solved
     , testCase "6: C (Either l x) (completeRules)" $
-        solveTest6 @?= [cL, cX]
+        solveTest6 @?= Right [cL, cX]
     , testCase "7: Sum test (completeRules)" $
-        solveTest7 @?= []
+        solveTest7 @?= solved
     , testCase "8: Sum test (partialRules)" $
-        solveTest8 @?= [cBool, cInt]
+        solveTest8 @?= Right [cBool, cInt]
     , testCase "9: Rec test (completeRules)" $
-        solveTest9 @?= []
+        solveTest9 @?= solved
     , testCase "10: Rec test (partialRules)" $
-        solveTest10 @?= [cBool, cInt]
+        solveTest10 @?= Right [cBool, cInt]
     , testCase "11: Prod test (completeRules)" $
-        solveTest11 @?= []
+        solveTest11 @?= solved
     , testCase "12: Prod test (partialRules)" $
-        solveTest12 @?= [cBool, cInt]
+        solveTest12 @?= Right [cBool, cInt]
     , testCase "13: Dec test (completeRules)" $
-        solveTest13 @?= []
+        solveTest13 @?= solved
     , testCase "14: Dec test (partialRules)" $
-        solveTest14 @?= [cBool, cInt]
+        solveTest14 @?= Right [cBool, cInt]
+    , testCase "15: Overlap test (specialrules)" $
+        solveTest15 @?= Left overlap
     ]
   where
+    solved :: Either Overlap [R.Constraint]
+    solved = Right []
+    cListMaybeInt = C _c (List (Maybe Int))
+    cMaybeInt = C _c (Maybe Int)
     cInt = C _c Int
     cBool = C _c Bool
-    cL = C _c _l
-    cX = C _c _x
+    cL = C _c vl
+    cX = C _c vr
     dInt = C _d Int
+    overlap =
+      Overlap
+        cMaybeInt
+        [ C _c (Maybe _X) :<= [C _c _X]
+        , C _c (Maybe Int) :<= []
+        ]
 
--- hardcoded variables, easier to read than (VarP "blah") everywhere
-_x, _xs, _vars, _name, _l, _body :: Pat
-_x = VarP "x"
-_xs = VarP "xs"
-_vars = VarP "vars"
-_name = VarP "name"
-_l = VarP "l"
-_body = VarP "body"
+-- hardcoded PATTERN variables, easier to read than (VarP "blah") everywhere
+_X, _XS, _VARS, _NAME, _L, _BODY :: Pat
+_X = VarP "x"
+_XS = VarP "xs"
+_VARS = VarP "vars"
+_NAME = VarP "name"
+_L = VarP "l"
+_BODY = VarP "body"
+
+-- hardcoded TYPE variables
+vl, vr :: Pat
+vl = TyVarP "l"
+vr = TyVarP "r"
 
 -- TODO(@gnumonik): Import this from somewhere else when that somewhere else module exists
 mkStructuralRules :: Class -> [Rule]
 mkStructuralRules c =
   [ C c Nil :<= []
-  , C c (_x :* _xs) :<= [C c _x, C c _xs]
-  , C c (_l := _x) :<= [C c _x]
-  , C c (RecP _xs) :<= [C c _xs]
-  , C c (ProdP _xs) :<= [C c _xs]
-  , C c (SumP _xs) :<= [C c _xs]
-  , C c (DecP _name _vars _body) :<= [C c _body]
+  , C c (_X :* _XS) :<= [C c _X, C c _XS]
+  , C c (_L := _X) :<= [C c _X]
+  , C c (RecP _XS) :<= [C c _XS]
+  , C c (ProdP _XS) :<= [C c _XS]
+  , C c (SumP _XS) :<= [C c _XS]
+  , C c (DecP _NAME _VARS _BODY) :<= [C c _BODY]
   ]
 
 pattern (:@) :: Pat -> Pat -> Pat
@@ -196,16 +214,16 @@ userRules1 :: Class -> [Rule]
 userRules1 c =
   [ NoConstraints c Int
   , NoConstraints c Bool
-  , C c (Maybe _x) :<= [C c _x]
-  , C c (Either _l _x) :<= [C c _l, C c _x]
-  , C c (List _x) :<= [C c _x]
+  , C c (Maybe _X) :<= [C c _X]
+  , C c (Either _L _X) :<= [C c _L, C c _X]
+  , C c (List _X) :<= [C c _X]
   ]
 
 userRules2 :: Class -> [Rule]
 userRules2 c =
-  [ C c (Maybe _x) :<= [C c _x]
-  , C c (Either _l _x) :<= [C c _l, C c _x]
-  , C c (List _x) :<= [C c _x]
+  [ C c (Maybe _X) :<= [C c _X]
+  , C c (Either _L _X) :<= [C c _L, C c _X]
+  , C c (List _X) :<= [C c _X]
   ]
 
 completeRules :: Class -> [Rule]
@@ -223,49 +241,48 @@ _d :: Class
 _d = Class (FQClassName "D" []) [_c]
 
 -- C [Maybe Int] w/ complete rules (expected: [])
-solveTest1 :: [R.Constraint]
+solveTest1 :: Either Overlap [R.Constraint]
 solveTest1 = solve (completeRules _c) (C _c $ List (Maybe Int))
 
--- D [Maybe Int] w/ incomplete rules (expected: [D Int])
-solveTest2 :: [R.Constraint]
+-- D [Maybe Int] w/ incomplete rules (expected: [C [Maybe Int], C (Maybe Int), D Int])
+solveTest2 :: Either Overlap [R.Constraint]
 solveTest2 = solve (partialRules _d) (C _d $ List (Maybe Int))
 
 -- D [Maybe Int] w/ complete D rules & incomplete C rules (expected: [C Int])
-solveTest3 :: [R.Constraint]
+solveTest3 :: Either Overlap [R.Constraint]
 solveTest3 = solve rules (C _d $ List (Maybe Int))
   where
     rules = completeRules _d <> partialRules _c
 
 -- C [[[Bool]]] w/ complete rules (expected: [])
-solveTest4 :: [R.Constraint]
+solveTest4 :: Either Overlap [R.Constraint]
 solveTest4 = solve (completeRules _c) $ C _c $ List (List (List Bool))
 
 -- C (Either (Either Int Bool) (Either Bool Int)) w/ complete rules (expected: [])
-solveTest5 :: [R.Constraint]
+solveTest5 :: Either Overlap [R.Constraint]
 solveTest5 = solve (completeRules _c) $ C _c $ Either (Either Int Bool) (Either Bool Int)
 
 -- NOTE(@bladyjoker): This one shows that we never need to "freshen" variables
---                    (if you study it you might also see why we never need to bind them)
 -- C (Either l x) w/ complete rules (expected: [C l, C x])
-solveTest6 :: [R.Constraint]
-solveTest6 = solve (completeRules _c) $ C _c $ Either _l _x
+solveTest6 :: Either Overlap [R.Constraint]
+solveTest6 = solve (completeRules _c) $ C _c $ Either vl vr
 
 -- tests for structural subcomponents of types. Can't write Haskell equivalents (w/o row-types)
 
 -- expected: []
-solveTest7 :: [R.Constraint]
+solveTest7 :: Either Overlap [R.Constraint]
 solveTest7 = solve (completeRules _c) $ C _c sumBody
   where
     sumBody = SumP $ Labeled "Ctor1" Int :* Labeled "Ctor2" (List Bool) :* Nil
 
 -- expected [C Bool, C Int]
-solveTest8 :: [R.Constraint]
+solveTest8 :: Either Overlap [R.Constraint]
 solveTest8 = solve (partialRules _c) $ C _c sumBody
   where
     sumBody = SumP $ Labeled "Ctor1" Int :* Labeled "Ctor2" (List Bool) :* Nil
 
 -- expected []
-solveTest9 :: [R.Constraint]
+solveTest9 :: Either Overlap [R.Constraint]
 solveTest9 = solve (completeRules _c) $ C _c recBody
   where
     recBody =
@@ -275,7 +292,7 @@ solveTest9 = solve (completeRules _c) $ C _c recBody
           :* Nil
 
 -- expected [C Bool, C Int]
-solveTest10 :: [R.Constraint]
+solveTest10 :: Either Overlap [R.Constraint]
 solveTest10 = solve (partialRules _c) $ C _c recBody
   where
     recBody =
@@ -285,19 +302,19 @@ solveTest10 = solve (partialRules _c) $ C _c recBody
           :* Nil
 
 -- expected []
-solveTest11 :: [R.Constraint]
+solveTest11 :: Either Overlap [R.Constraint]
 solveTest11 = solve (completeRules _c) $ C _c prodBody
   where
     prodBody = ProdP $ List Bool :* Either Int Bool :* Nil
 
 -- expected [C Bool, C Int]
-solveTest12 :: [R.Constraint]
+solveTest12 :: Either Overlap [R.Constraint]
 solveTest12 = solve (partialRules _c) $ C _c prodBody
   where
     prodBody = ProdP $ List Bool :* Either Int Bool :* Nil
 
 -- expected []
-solveTest13 :: [R.Constraint]
+solveTest13 :: Either Overlap [R.Constraint]
 solveTest13 = solve (completeRules _c) $ C _c testDec
   where
     testDec =
@@ -308,7 +325,7 @@ solveTest13 = solve (completeRules _c) $ C _c testDec
             :* Nil
 
 -- expected [C Int, C Bool]
-solveTest14 :: [R.Constraint]
+solveTest14 :: Either Overlap [R.Constraint]
 solveTest14 = solve (partialRules _c) $ C _c testDec
   where
     testDec =
@@ -317,3 +334,14 @@ solveTest14 = solve (partialRules _c) $ C _c testDec
           Labeled "Ctor1" (ProdP $ Maybe Int :* Nil)
             :* Labeled "Ctor2" (RecP $ Labeled "field1" Bool :* Nil)
             :* Nil
+
+-- expected overlap
+solveTest15 :: Either Overlap [R.Constraint]
+solveTest15 = solve cOverlapRules (C _c $ List (Maybe Int))
+  where
+    cOverlapRules =
+      [ C _c (Maybe _X) :<= [C _c _X]
+      , C _c (Maybe Int) :<= []
+      , C _c Int :<= []
+      , C _c (List _X) :<= [C _c _X]
+      ]

--- a/lambda-buffers-compiler/test/Test/TypeClassCheck.hs
+++ b/lambda-buffers-compiler/test/Test/TypeClassCheck.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE PatternSynonyms #-}
+
 module Test.TypeClassCheck (test) where
 
 import Control.Lens ((.~))
@@ -7,6 +9,29 @@ import Data.Text (Text)
 import Data.Traversable (for)
 import LambdaBuffers.Compiler.ProtoCompat (IsMessage (fromProto))
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as ProtoCompat
+import LambdaBuffers.Compiler.TypeClass.Pat (
+  Pat (
+    AppP,
+    DecP,
+    Name,
+    Nil,
+    ProdP,
+    RecP,
+    RefP,
+    SumP,
+    VarP,
+    (:*),
+    (:=)
+  ),
+ )
+import LambdaBuffers.Compiler.TypeClass.Rules (
+  Class (Class),
+  Constraint (C),
+  FQClassName (FQClassName),
+  Rule ((:<=)),
+ )
+import LambdaBuffers.Compiler.TypeClass.Rules qualified as R
+import LambdaBuffers.Compiler.TypeClass.Solve (solve)
 import LambdaBuffers.Compiler.TypeClassCheck (detectSuperclassCycles')
 import Proto.Compiler (ClassDef, Constraint, Kind, Kind'KindRef (Kind'KIND_REF_TYPE))
 import Proto.Compiler_Fields (argKind, argName, arguments, classArgs, className, classRef, kindRef, localClassRef, name, supers, tyVar, varName)
@@ -15,6 +40,12 @@ import Test.Tasty.HUnit (assertFailure, testCase, (@?=))
 
 test :: TestTree
 test =
+  testGroup
+    "TypeClass tests"
+    [cycleTests, solveTests]
+
+cycleTests :: TestTree
+cycleTests =
   testGroup
     "TypeClassCheck tests"
     [ noCycleDetected
@@ -50,7 +81,7 @@ mkclass nm sups =
          ]
     & supers .~ map constraint sups
 
-constraint :: Text -> Constraint
+constraint :: Text -> Proto.Compiler.Constraint
 constraint nm =
   defMessage
     & classRef . localClassRef . className . name .~ nm
@@ -70,3 +101,219 @@ nocycles =
   , mkclass "Monad" ["Applicative"]
   , mkclass "Traversable" ["Foldable", "Functor"]
   ]
+
+---- Solver tests
+
+solveTests :: TestTree
+solveTests =
+  testGroup
+    "Solver tests"
+    [ testCase "1: C [Maybe Int] (completeRules)" $
+        solveTest1 @?= []
+    , testCase "2: D [Maybe Int] (partialRules)" $
+        solveTest2 @?= [dInt]
+    , testCase "3: D [Maybe Int] (complete D, partial C)" $
+        solveTest3 @?= [cInt]
+    , testCase "4: C [[[Bool]]] (completeRules)" $
+        solveTest4 @?= []
+    , testCase "5: C (Either (Either Int Bool) (Either Bool Int)) (completeRules)" $
+        solveTest5 @?= []
+    , testCase "6: C (Either l x) (completeRules)" $
+        solveTest6 @?= [cL, cX]
+    , testCase "7: Sum test (completeRules)" $
+        solveTest7 @?= []
+    , testCase "8: Sum test (partialRules)" $
+        solveTest8 @?= [cBool, cInt]
+    , testCase "9: Rec test (completeRules)" $
+        solveTest9 @?= []
+    , testCase "10: Rec test (partialRules)" $
+        solveTest10 @?= [cBool, cInt]
+    , testCase "11: Prod test (completeRules)" $
+        solveTest11 @?= []
+    , testCase "12: Prod test (partialRules)" $
+        solveTest12 @?= [cBool, cInt]
+    , testCase "13: Dec test (completeRules)" $
+        solveTest13 @?= []
+    , testCase "14: Dec test (partialRules)" $
+        solveTest14 @?= [cBool, cInt]
+    ]
+  where
+    cInt = C _c Int
+    cBool = C _c Bool
+    cL = C _c _l
+    cX = C _c _x
+    dInt = C _d Int
+
+-- hardcoded variables, easier to read than (VarP "blah") everywhere
+_x, _xs, _vars, _name, _l, _body :: Pat
+_x = VarP "x"
+_xs = VarP "xs"
+_vars = VarP "vars"
+_name = VarP "name"
+_l = VarP "l"
+_body = VarP "body"
+
+-- TODO(@gnumonik): Import this from somewhere else when that somewhere else module exists
+mkStructuralRules :: Class -> [Rule]
+mkStructuralRules c =
+  [ C c Nil :<= []
+  , C c (_x :* _xs) :<= [C c _x, C c _xs]
+  , C c (_l := _x) :<= [C c _x]
+  , C c (RecP _xs) :<= [C c _xs]
+  , C c (ProdP _xs) :<= [C c _xs]
+  , C c (SumP _xs) :<= [C c _xs]
+  , C c (DecP _name _vars _body) :<= [C c _body]
+  ]
+
+pattern (:@) :: Pat -> Pat -> Pat
+pattern (:@) p1 p2 = AppP p1 p2
+
+pattern LocalRef :: Text -> Pat
+pattern LocalRef nm = RefP Nil (Name nm)
+
+pattern Maybe :: Pat -> Pat
+pattern Maybe p1 = LocalRef "Maybe" :@ p1
+
+pattern List :: Pat -> Pat
+pattern List p = LocalRef "List" :@ p
+
+pattern Either :: Pat -> Pat -> Pat
+pattern Either l r = (LocalRef "Either" :@ l) :@ r
+
+pattern Int :: Pat
+pattern Int = LocalRef "Int"
+
+pattern Bool :: Pat
+pattern Bool = LocalRef "Bool"
+
+pattern NoConstraints :: Class -> Pat -> Rule
+pattern NoConstraints c p = C c p :<= []
+
+pattern Labeled :: Text -> Pat -> Pat
+pattern Labeled nm p = Name nm := p
+
+userRules1 :: Class -> [Rule]
+userRules1 c =
+  [ NoConstraints c Int
+  , NoConstraints c Bool
+  , C c (Maybe _x) :<= [C c _x]
+  , C c (Either _l _x) :<= [C c _l, C c _x]
+  , C c (List _x) :<= [C c _x]
+  ]
+
+userRules2 :: Class -> [Rule]
+userRules2 c =
+  [ C c (Maybe _x) :<= [C c _x]
+  , C c (Either _l _x) :<= [C c _l, C c _x]
+  , C c (List _x) :<= [C c _x]
+  ]
+
+completeRules :: Class -> [Rule]
+completeRules c = mkStructuralRules c <> userRules1 c
+
+partialRules :: Class -> [Rule]
+partialRules c = mkStructuralRules c <> userRules2 c
+
+-- No supers
+_c :: Class
+_c = Class (FQClassName "C" []) []
+
+-- C is super
+_d :: Class
+_d = Class (FQClassName "D" []) [_c]
+
+-- C [Maybe Int] w/ complete rules (expected: [])
+solveTest1 :: [R.Constraint]
+solveTest1 = solve (completeRules _c) (C _c $ List (Maybe Int))
+
+-- D [Maybe Int] w/ incomplete rules (expected: [D Int])
+solveTest2 :: [R.Constraint]
+solveTest2 = solve (partialRules _d) (C _d $ List (Maybe Int))
+
+-- D [Maybe Int] w/ complete D rules & incomplete C rules (expected: [C Int])
+solveTest3 :: [R.Constraint]
+solveTest3 = solve rules (C _d $ List (Maybe Int))
+  where
+    rules = completeRules _d <> partialRules _c
+
+-- C [[[Bool]]] w/ complete rules (expected: [])
+solveTest4 :: [R.Constraint]
+solveTest4 = solve (completeRules _c) $ C _c $ List (List (List Bool))
+
+-- C (Either (Either Int Bool) (Either Bool Int)) w/ complete rules (expected: [])
+solveTest5 :: [R.Constraint]
+solveTest5 = solve (completeRules _c) $ C _c $ Either (Either Int Bool) (Either Bool Int)
+
+-- NOTE(@bladyjoker): This one shows that we never need to "freshen" variables
+--                    (if you study it you might also see why we never need to bind them)
+-- C (Either l x) w/ complete rules (expected: [C l, C x])
+solveTest6 :: [R.Constraint]
+solveTest6 = solve (completeRules _c) $ C _c $ Either _l _x
+
+-- tests for structural subcomponents of types. Can't write Haskell equivalents (w/o row-types)
+
+-- expected: []
+solveTest7 :: [R.Constraint]
+solveTest7 = solve (completeRules _c) $ C _c sumBody
+  where
+    sumBody = SumP $ Labeled "Ctor1" Int :* Labeled "Ctor2" (List Bool) :* Nil
+
+-- expected [C Bool, C Int]
+solveTest8 :: [R.Constraint]
+solveTest8 = solve (partialRules _c) $ C _c sumBody
+  where
+    sumBody = SumP $ Labeled "Ctor1" Int :* Labeled "Ctor2" (List Bool) :* Nil
+
+-- expected []
+solveTest9 :: [R.Constraint]
+solveTest9 = solve (completeRules _c) $ C _c recBody
+  where
+    recBody =
+      RecP $
+        Labeled "field1" (Maybe Bool)
+          :* Labeled "field2" (Either Int (List Int))
+          :* Nil
+
+-- expected [C Bool, C Int]
+solveTest10 :: [R.Constraint]
+solveTest10 = solve (partialRules _c) $ C _c recBody
+  where
+    recBody =
+      RecP $
+        Labeled "field1" (Maybe Bool)
+          :* Labeled "field2" (Either Int (List Int))
+          :* Nil
+
+-- expected []
+solveTest11 :: [R.Constraint]
+solveTest11 = solve (completeRules _c) $ C _c prodBody
+  where
+    prodBody = ProdP $ List Bool :* Either Int Bool :* Nil
+
+-- expected [C Bool, C Int]
+solveTest12 :: [R.Constraint]
+solveTest12 = solve (partialRules _c) $ C _c prodBody
+  where
+    prodBody = ProdP $ List Bool :* Either Int Bool :* Nil
+
+-- expected []
+solveTest13 :: [R.Constraint]
+solveTest13 = solve (completeRules _c) $ C _c testDec
+  where
+    testDec =
+      DecP (Name "Foo") Nil $
+        SumP $
+          Labeled "Ctor1" (ProdP $ Maybe Int :* Nil)
+            :* Labeled "Ctor2" (RecP $ Labeled "field1" Bool :* Nil)
+            :* Nil
+
+-- expected [C Int, C Bool]
+solveTest14 :: [R.Constraint]
+solveTest14 = solve (partialRules _c) $ C _c testDec
+  where
+    testDec =
+      DecP (Name "Foo") Nil $
+        SumP $
+          Labeled "Ctor1" (ProdP $ Maybe Int :* Nil)
+            :* Labeled "Ctor2" (RecP $ Labeled "field1" Bool :* Nil)
+            :* Nil

--- a/lambda-buffers-compiler/test/Test/TypeClassCheck.hs
+++ b/lambda-buffers-compiler/test/Test/TypeClassCheck.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 
-module Test.TypeClassCheck {- (test) -} where
+module Test.TypeClassCheck (test) where
 
 import Control.Lens ((.~))
 import Data.Function ((&))


### PR DESCRIPTION
This PR contains the solver (rewritten to avoid use of flip), a few small changes in response to comments from the last PR, and a suite of tests for the solver. 

@bladyjoker 
 - #41 / #42 can be done in the next PR. I'll have to rewrite the cycle detection *again* once I have the stuff from `Utils` in, there's not much of a point in doing it here only to redo it again tomorrow 
 - #40 is a proto-level change that would require a bunch of rewrites and seems out of place here (you told me to keep the PRs small). I'll do it in a standalone PR either before or after I get `Utils` & co merged 
