### PR TITLE
Removed InstanceClause, replaced with DeriveClause

### DIFF
--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/FromProto.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/FromProto.hs
@@ -553,23 +553,21 @@ instance IsMessage P.ClassDef PC.ClassDef where
       & P.documentation .~ doc
       & P.sourceInfo .~ toProto si
 
-instance IsMessage P.InstanceClause PC.InstanceClause where
+instance IsMessage P.DeriveClause PC.DeriveClause where
   fromProto ic = do
     si <- fromProto $ ic ^. P.sourceInfo
     cnm <- fromProto $ ic ^. P.classRef
-    csts <- traverse fromProto $ ic ^. P.constraints
     args <- traverse fromProto $ ic ^. P.args
     arg <- case args of
       [] -> throwInternalError "Zero instance arguments, but zero parameter type classes are not supported"
       [x] -> return x
       _ -> throwInternalError "Multiple instance arguments, but multi parameter type classes are not supported"
-    pure $ PC.InstanceClause cnm arg csts si
+    pure $ PC.DeriveClause cnm arg si
 
-  toProto (PC.InstanceClause cnm hd csts si) =
+  toProto (PC.DeriveClause cnm hd si) =
     defMessage
       & P.classRef .~ toProto cnm
       & P.args .~ pure (toProto hd)
-      & P.constraints .~ (toProto <$> csts)
       & P.sourceInfo .~ toProto si
 
 instance IsMessage P.Constraint PC.Constraint where

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Types.hs
@@ -19,7 +19,7 @@ module LambdaBuffers.Compiler.ProtoCompat.Types (
   FieldName (..),
   ForeignRef (..),
   ForeignClassRef (..),
-  InstanceClause (..),
+  DeriveClause (..),
   Kind (..),
   KindRefType (..),
   KindCheckError (..),
@@ -240,21 +240,19 @@ data ClassDef = ClassDef
   deriving stock (Show, Eq, Ord, Generic)
   deriving (Arbitrary) via GenericArbitrary ClassDef
 
-data InstanceClause = InstanceClause
+data DeriveClause = DeriveClause
   { classRef :: TyClassRef
   , head :: Ty
-  , constraints :: [Constraint]
   , sourceInfo :: SourceInfo
   }
   deriving stock (Show, Eq, Ord, Generic)
 
-instance Arbitrary InstanceClause where
+instance Arbitrary DeriveClause where
   arbitrary = sized fn
     where
       fn n =
-        InstanceClause
+        DeriveClause
           <$> resize n arbitrary
-          <*> resize n arbitrary
           <*> resize n arbitrary
           <*> resize n arbitrary
 
@@ -270,7 +268,7 @@ data Module = Module
   { moduleName :: ModuleName
   , typeDefs :: Map TyName TyDef
   , classDefs :: Map ClassName ClassDef
-  , instances :: [InstanceClause]
+  , instances :: [DeriveClause]
   , imports :: Set ModuleName
   , sourceInfo :: SourceInfo
   }

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Utils.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Utils.hs
@@ -43,7 +43,6 @@ import Data.Text (Text)
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P (
   ClassDef,
   CompilerInput (CompilerInput),
-  Constraint (Constraint),
   DeriveClause (DeriveClause),
   Module,
   ModuleName,

--- a/lambda-buffers-compiler/test/Test/Utils/Constructors.hs
+++ b/lambda-buffers-compiler/test/Test/Utils/Constructors.hs
@@ -36,7 +36,7 @@ _CompilerInput ms =
     { P.modules = Map.fromList [(m ^. #moduleName, m) | m <- ms]
     }
 
-_Module :: P.ModuleName -> [P.TyDef] -> [P.ClassDef] -> [P.InstanceClause] -> P.Module
+_Module :: P.ModuleName -> [P.TyDef] -> [P.ClassDef] -> [P.DeriveClause] -> P.Module
 _Module mn tds cds ins =
   P.Module
     { P.moduleName = mn

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -463,19 +463,16 @@ message TyClassRef {
   }
 }
 
-/* Type class instances (rules)
+/* Type class instance deriving clauses
 
-Instance clauses enable users to specify 'semantic' rules for their types.
+Deriving clauses enable users to specify 'semantic' rules for their types.
 */
-message InstanceClause {
+message DeriveClause {
   // Type class name.
   TyClassRef class_ref = 1;
-  // Instance (rule) arguments.
-  // Instance clause with no arguments is a trivial instance clause.
+  // Derive clause arguments .
   // Compiler MAY report an error.
   repeated Ty args = 2;
-  // Instance (rule) body, conjunction of constraints.
-  repeated Constraint constraints = 3;
   // Source information.
   SourceInfo source_info = 4;
 }
@@ -508,7 +505,7 @@ message Module {
   // `ProtoParseError.MultipleClassDefError`.
   repeated ClassDef class_defs = 3;
   // Type class instance clauses.
-  repeated InstanceClause instances = 4;
+  repeated DeriveClause instances = 4;
   // Imported modules the Compiler consults when searching for
   // instance clauses.
   // Duplicate imports MUST be reported with


### PR DESCRIPTION
Small-ish change. It might be a good idea to leave `InstanceClause` in solely for communicating with the CodeGen component? Consider: 

```
data Foo a b = MkFoo a b 

derive Eq (Foo a b)
```

The typeclass-check stuff knows that the instance that needs to be derived is `instance (Eq a, Eq b) => Eq (Foo a b)`. And it is easy enough to determine this in the codegen - you just walk the SOP and collect free TyVars, since under "structural deriving" the context needs to contain `C a, C b, ...` for each TyVar (and only for each TyVar). Not sure what the best thing to do here is. 