### PR TITLE
API Typeclass Errors 

### DIFF
--- a/lambda-buffers-compiler/lambda-buffers-compiler.cabal
+++ b/lambda-buffers-compiler/lambda-buffers-compiler.cabal
@@ -122,6 +122,7 @@ library
     LambdaBuffers.Compiler.ProtoCompat.Types
     LambdaBuffers.Compiler.TypeClassCheck
     LambdaBuffers.Compiler.TypeClassCheck.Compat
+    LambdaBuffers.Compiler.TypeClassCheck.Errors
     LambdaBuffers.Compiler.TypeClassCheck.Pat
     LambdaBuffers.Compiler.TypeClassCheck.Pretty
     LambdaBuffers.Compiler.TypeClassCheck.Rules

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck.hs
@@ -19,12 +19,14 @@ import LambdaBuffers.Compiler.ProtoCompat.Types (
   LocalClassRef (LocalClassRef),
   TyClassRef (ForeignCI, LocalCI),
  )
+import LambdaBuffers.Compiler.TypeClassCheck.Errors (
+  Instance,
+  TypeClassError (FailedToSolveConstraints),
+ )
 import LambdaBuffers.Compiler.TypeClassCheck.Pretty (spaced, (<//>))
 import LambdaBuffers.Compiler.TypeClassCheck.Utils (
-  Instance,
   ModuleBuilder (mbInstances),
   Tagged,
-  TypeClassError (FailedToSolveConstraints),
   checkInstance,
   getTag,
   mkBuilders,

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Errors.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Errors.hs
@@ -1,0 +1,129 @@
+module LambdaBuffers.Compiler.TypeClassCheck.Errors (
+  type Instance,
+  TypeClassError (UnknownClass, UnknownModule, MissingModuleInstances, MissingModuleScope, ClassNotFoundInModule, LocalTyRefNotFound, SuperclassCycleDetected, FailedToSolveConstraints, MalformedTyDef, BadInstance),
+  BasicConditionViolation (TyConInContext, OverlapDetected, OnlyTyVarsInHead),
+) where
+
+import GHC.Generics (Generic)
+
+import Data.Text qualified as T
+
+import LambdaBuffers.Compiler.TypeClassCheck.Rules (
+  Constraint,
+  FQClassName,
+  Rule,
+ )
+
+import Data.Text (Text)
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P (
+  ModuleName,
+  SourceInfo,
+ )
+import LambdaBuffers.Compiler.TypeClassCheck.Pat (Exp, Pat)
+
+import LambdaBuffers.Compiler.TypeClassCheck.Pretty (pointies, (<///>))
+import LambdaBuffers.Compiler.TypeClassCheck.Solve (Overlap (Overlap))
+import Prettyprinter (
+  Pretty (pretty),
+  hcat,
+  indent,
+  line,
+  nest,
+  punctuate,
+  vcat,
+  (<+>),
+ )
+
+type Instance = Rule Pat
+
+{- Some of these are perfunctory & used to keep functions total.
+-}
+data TypeClassError
+  = UnknownClass FQClassName P.SourceInfo -- this might need split into two, investigate further
+  | UnknownModule P.ModuleName -- internal, no sourceInfo (doesn't make sense)
+  | MissingModuleInstances P.ModuleName -- internal, no sourceInfo (doesn't make sense)
+  | MissingModuleScope P.ModuleName -- internal, no sourceinfo (doesn't make sense)
+  | ClassNotFoundInModule Text [Text] -- this one's weird. there's not really one place in the source that triggers it. come back to it later
+  | LocalTyRefNotFound T.Text P.ModuleName P.SourceInfo -- SI is the instance clause that triggered the tyref lookup
+  | SuperclassCycleDetected [[FQClassName]] -- No sourceinfo, it's not very useful due to the nature of cycles
+  | FailedToSolveConstraints P.ModuleName [Constraint Exp] Instance P.SourceInfo -- SI is the instance clause that triggered the subgoal that failed (subgoal itself may not exist anywhere in the source)
+  | MalformedTyDef P.ModuleName Exp P.SourceInfo -- SI is the BODY of the exp
+  | BadInstance BasicConditionViolation P.SourceInfo -- SI is the source of the rule that triggered the violation. This might be weird
+  deriving stock (Show, Eq, Generic)
+
+instance Pretty TypeClassError where
+  pretty = \case
+    UnknownClass cref si ->
+      "Error at" <+> pretty si <+> nest 2 ("Unknown class: " <> pretty cref)
+    UnknownModule mn ->
+      "INTERNAL ERROR: Unknown Module" <+> pretty mn
+    MissingModuleInstances mn ->
+      "INTERNAL ERROR: Missing instance data for module" <+> pretty mn
+    MissingModuleScope mn ->
+      "INTERNAL ERROR: Could not determine TypeClass scope for module" <+> pretty mn
+    ClassNotFoundInModule cn mn ->
+      "Error: Expected to find class"
+        <+> pretty cn
+        <+> "in module"
+        <+> pretty mn
+        <+> "but it isn't there!"
+    LocalTyRefNotFound txt mn _ ->
+      "Error: Expected to find a type definition for a type named"
+        <+> pretty txt
+        <+> "in module"
+        <+> pretty mn
+        <+> "but it isn't there!"
+    SuperclassCycleDetected crs ->
+      "Error: Superclass cycles detected in compiler input:"
+        <+> nest
+          2
+          ( vcat
+              . map (hcat . punctuate " => " . map pretty)
+              $ crs
+          )
+    FailedToSolveConstraints mn cs i _ ->
+      "Error: Could not derive instance:"
+        <+> pointies (pretty i)
+          <> line
+          <> line
+          <> indent 2 "in module"
+        <+> pretty mn
+          <> line
+          <> line
+          <> indent 2 "because the following constraint(s) were not satisfied:"
+          <> line
+          <> line
+          <> indent 2 (vcat $ map pretty cs)
+    MalformedTyDef mn xp _ ->
+      "Error: Encountered malformed type definition:"
+        <> line
+        <> indent 2 (pretty xp)
+        <> line
+        <> indent 2 ("in module" <+> pretty mn)
+    BadInstance bcv _ -> pretty bcv
+
+data BasicConditionViolation
+  = TyConInContext Instance (Constraint Pat)
+  | OnlyTyVarsInHead Instance (Constraint Pat)
+  | OverlapDetected Overlap
+  deriving stock (Show, Eq, Generic)
+
+instance Pretty BasicConditionViolation where
+  pretty = \case
+    TyConInContext inst cst ->
+      "Error: Invalid instance declaration!"
+        <///> indent 2 (pretty inst)
+        <///> "The instance constraint"
+        <///> indent 2 (pretty cst)
+        <///> "Contains a type constructor, but may only contain type variables"
+    OnlyTyVarsInHead inst cst ->
+      "Error: Invalid instance declaration!"
+        <///> indent 2 (pretty inst)
+        <///> "The instance constraint"
+        <///> indent 2 (pretty cst)
+        <///> "only contains type variables, but must contain at least one constructor"
+    OverlapDetected (Overlap cst rules) ->
+      "Error: Overlapping instances detected when trying to solve constraint"
+        <+> pretty cst
+          <> line
+          <> indent 2 (vcat (map pretty rules))

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Errors.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Errors.hs
@@ -43,7 +43,7 @@ data TypeClassError
   | UnknownModule P.ModuleName -- internal, no sourceInfo (doesn't make sense)
   | MissingModuleInstances P.ModuleName -- internal, no sourceInfo (doesn't make sense)
   | MissingModuleScope P.ModuleName -- internal, no sourceinfo (doesn't make sense)
-  | ClassNotFoundInModule Text [Text] -- this one's weird. there's not really one place in the source that triggers it. come back to it later
+  | ClassNotFoundInModule Text [Text] -- internal-ish? this one's weird. there's not really one place in the source that triggers it. come back to it later
   | LocalTyRefNotFound T.Text P.ModuleName P.SourceInfo -- SI is the instance clause that triggered the tyref lookup
   | SuperclassCycleDetected [[FQClassName]] -- No sourceinfo, it's not very useful due to the nature of cycles
   | FailedToSolveConstraints P.ModuleName [Constraint Exp] Instance P.SourceInfo -- SI is the instance clause that triggered the subgoal that failed (subgoal itself may not exist anywhere in the source)

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Pat.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Pat.hs
@@ -19,6 +19,9 @@ module LambdaBuffers.Compiler.TypeClassCheck.Pat (
   -- stupid utility for errors
   unTyFunP,
   unTyFunE,
+  Tagged (..),
+  unTag,
+  getTag,
   -- for tests, remove
   pattern Either,
   pattern Bool,
@@ -27,6 +30,8 @@ module LambdaBuffers.Compiler.TypeClassCheck.Pat (
 
 import Data.Kind (Type)
 import Data.Text (Text)
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P
+import Prettyprinter (Pretty (pretty))
 
 {- A simple ADT to represent patterns.
 
@@ -219,3 +224,28 @@ matches (DecP t1 t2 t3) (DecE t1' t2' t3') =
   matches t1 t1' && matches t2 t2' && matches t3 t3'
 matches NilP NilE = True
 matches _ _ = False
+
+data Tagged :: Type -> Type where
+  Tag :: P.SourceInfo -> a -> Tagged a
+
+instance Functor Tagged where
+  fmap f (Tag si a) = Tag si (f a)
+
+unTag :: forall a. Tagged a -> a
+unTag (Tag _ a) = a
+
+getTag :: forall a. Tagged a -> P.SourceInfo
+getTag (Tag si _) = si
+
+instance Eq a => Eq (Tagged a) where
+  (Tag _ a) == (Tag _ a') = a == a'
+
+instance Ord a => Ord (Tagged a) where
+  (Tag _ a) <= (Tag _ a') = a <= a'
+
+-- DEGENERATE but need for debugging
+instance Show a => Show (Tagged a) where
+  show (Tag _ a) = show a
+
+instance Pretty a => Pretty (Tagged a) where
+  pretty (Tag _ a) = pretty a

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Validate.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/TypeClassCheck/Validate.hs
@@ -18,6 +18,11 @@ import Control.Monad.Except (throwError)
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as P (
   ModuleName,
  )
+import LambdaBuffers.Compiler.TypeClassCheck.Errors (
+  BasicConditionViolation (OverlapDetected),
+  Instance,
+  TypeClassError (BadInstance, LocalTyRefNotFound, MalformedTyDef),
+ )
 import LambdaBuffers.Compiler.TypeClassCheck.Pat (Exp (DecE), Literal (Opaque), Pat (ConsP, LabelP, LitP, NilP, ProdP, RecP, SumP, VarP), getLocalRefE)
 import LambdaBuffers.Compiler.TypeClassCheck.Rules (
   Class,
@@ -26,11 +31,8 @@ import LambdaBuffers.Compiler.TypeClassCheck.Rules (
  )
 import LambdaBuffers.Compiler.TypeClassCheck.Solve (Overlap, inst, solve)
 import LambdaBuffers.Compiler.TypeClassCheck.Utils (
-  BasicConditionViolation (OverlapDetected),
-  Instance,
   ModuleBuilder (mbInstances, mbScope, mbTyDefs),
   Tagged (Tag),
-  TypeClassError (BadInstance, LocalTyRefNotFound, MalformedTyDef),
   getTag,
   lookupOr,
   unTag,

--- a/lambda-buffers-compiler/test/Test/DeriveCheck.hs
+++ b/lambda-buffers-compiler/test/Test/DeriveCheck.hs
@@ -12,6 +12,11 @@ import Data.Set qualified as S
 import Data.Text (Text)
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
 import LambdaBuffers.Compiler.TypeClassCheck (runDeriveCheck)
+import LambdaBuffers.Compiler.TypeClassCheck.Errors (
+  BasicConditionViolation (OverlapDetected, TyConInContext),
+  Instance,
+  TypeClassError (BadInstance),
+ )
 import LambdaBuffers.Compiler.TypeClassCheck.Pat (
   Exp (AppE, DecE, LitE, NilE, RefE),
   ExpressionLike (nil, (*:), (*=)),
@@ -27,11 +32,8 @@ import LambdaBuffers.Compiler.TypeClassCheck.Rules (
   Rule ((:<=)),
  )
 import LambdaBuffers.Compiler.TypeClassCheck.Utils (
-  BasicConditionViolation (OverlapDetected, TyConInContext),
-  Instance,
   ModuleBuilder (ModuleBuilder, mbClasses, mbInstances, mbScope, mbTyDefs),
   Tagged (Tag),
-  TypeClassError (BadInstance),
  )
 import LambdaBuffers.Compiler.TypeClassCheck.Validate (_X)
 import Test.Tasty (TestTree, testGroup)

--- a/lambda-buffers-compiler/test/Test/DeriveCheck.hs
+++ b/lambda-buffers-compiler/test/Test/DeriveCheck.hs
@@ -31,6 +31,7 @@ import LambdaBuffers.Compiler.TypeClassCheck.Rules (
   FQClassName (FQClassName),
   Rule ((:<=)),
  )
+import LambdaBuffers.Compiler.TypeClassCheck.Solve (defTag)
 import LambdaBuffers.Compiler.TypeClassCheck.Utils (
   ModuleBuilder (ModuleBuilder, mbClasses, mbInstances, mbScope, mbTyDefs),
   Tagged (Tag),
@@ -272,10 +273,11 @@ moduleB'1 =
         ]
 
     scopeB =
-      S.fromList
-        [ C _c (ForeignRefP ["A"] "Int") :<= []
-        , C _c (ForeignRefP ["A"] "Maybe" :@ _X) :<= [C _c _X]
-        ]
+      S.fromList $
+        defTag
+          <$> [ C _c (ForeignRefP ["A"] "Int") :<= []
+              , C _c (ForeignRefP ["A"] "Maybe" :@ _X) :<= [C _c _X]
+              ]
 
     instancesB = S.fromList [C _c (LocalRefP "Foo") :<= []]
 
@@ -314,9 +316,10 @@ moduleB'2 =
         ]
 
     scopeB =
-      S.fromList
-        [ C _c (ForeignRefP ["A"] "Maybe" :@ _X) :<= [C _c _X]
-        ]
+      S.fromList $
+        defTag
+          <$> [ C _c (ForeignRefP ["A"] "Maybe" :@ _X) :<= [C _c _X]
+              ]
 
     instancesB = S.fromList [C _c (LocalRefP "Foo" :@ _X) :<= [C _c _X]]
 
@@ -386,11 +389,12 @@ moduleB'4 =
         ]
 
     scopeB =
-      S.fromList
-        [ C _c (ForeignRefP ["A"] "Int") :<= []
-        , C _c (ForeignRefP ["A"] "Maybe" :@ _X) :<= [C _c _X]
-        , C _c (ForeignRefP ["A"] "Maybe" :@ ForeignRefP ["A"] "Int") :<= []
-        ]
+      S.fromList $
+        defTag
+          <$> [ C _c (ForeignRefP ["A"] "Int") :<= []
+              , C _c (ForeignRefP ["A"] "Maybe" :@ _X) :<= [C _c _X]
+              , C _c (ForeignRefP ["A"] "Maybe" :@ ForeignRefP ["A"] "Int") :<= []
+              ]
 
     instancesB = S.fromList [C _c (LocalRefP "Foo") :<= []]
 
@@ -418,9 +422,10 @@ moduleB'5 =
         ]
 
     scopeB =
-      S.fromList
-        [ C _c (ForeignRefP ["A"] "Maybe" :@ _X) :<= [C _c _X]
-        ]
+      S.fromList $
+        defTag
+          <$> [ C _c (ForeignRefP ["A"] "Maybe" :@ _X) :<= [C _c _X]
+              ]
 
     instancesB = S.fromList [C _c (LocalRefP "Foo") :<= []]
 
@@ -483,9 +488,10 @@ moduleC'1 =
         ]
 
     scopeC =
-      S.fromList
-        [ C _c (ForeignRefP ["A"] "Int") :<= []
-        ]
+      S.fromList $
+        defTag
+          <$> [ C _c (ForeignRefP ["A"] "Int") :<= []
+              ]
 
     instancesC = S.fromList [C _c (LocalRefP "Bar" :@ tyVarP "a" :@ tyVarP "b") :<= []]
 
@@ -519,9 +525,10 @@ moduleD'1 =
         ]
 
     scopeD =
-      S.fromList
-        [ C _c (ForeignRefP ["A"] "Int") :<= []
-        ]
+      S.fromList $
+        defTag
+          <$> [ C _c (ForeignRefP ["A"] "Int") :<= []
+              ]
 
     instancesD = S.fromList [C _c (LocalRefP "Bar" :@ tyVarP "a" :@ tyVarP "b") :<= []]
 
@@ -555,9 +562,10 @@ moduleD'2 =
         ]
 
     scopeD =
-      S.fromList
-        [ C _c (ForeignRefP ["A"] "Int") :<= []
-        ]
+      S.fromList $
+        defTag
+          <$> [ C _c (ForeignRefP ["A"] "Int") :<= []
+              ]
 
     instancesD =
       S.fromList

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -633,71 +633,86 @@ message ProtoParseError {
   }
 }
 
-// Non-internal errors that can be thrown during
-// type class checking. Because these errors involve
-// TyClassCheck types, which cannot be converted back into
-// proto messages, the error message is constructed in the
-// TypeClassCheck modules in LambdaBuffers.Compiler
 message TypeClassError {
-  // Error which indicates that a class referred to in an instance
+  // A class referred to in an instance
   // or deriving clause does not exist. (Maybe this should be internal?)
   message UnknownClassError {
-    string msg = 1;
-    SourceInfo source_info = 2;
+    // The reference that could not be resolved
+    // NOTE: the class_ref contains valid/"real" source info
+    TyClassRef class_ref = 1;
   }
 
-  // Error which indicates that the TyDef referred to by a TyRef cannot be found
+  // The TyDef referred to by a TyRef cannot be found
   message LocalTyRefNotFoundError {
-    string msg = 1;
+    // NOTE: Has defaulted SourceInfo
+    TyName ty_name = 1;
+    // The module where the missing reference was searched for
+    ModuleName module_name = 2;
     // SourceInfo points to the clause that triggered the tyref lookup
-    SourceInfo source_info = 2;
+    SourceInfo source_info = 3;
   }
 
-  // Error which indicates a cycle of superclasses. SourceInfo
-  // isn't particularly meaningful here - we could include the SourceInfo
-  // for each class in the cycle, but given the large amount of work
-  // required to define a LB class, this should be more than adequate
+  // Detected a superclass cycle
   message SuperclassCycleError {
+    // TODO(@gnumonik): fix later if drazen is OK w/ the other ones,
+    // this one is not that important
     string msg  = 1;
   }
 
-  // Error that indicates a constraint cannot be solved with
+  // A constraint cannot be solved with
   // the in-scope set of instance rules.
-  message FailedToSolveConstraintError {
-    string msg = 1;
-    // SourceInfo points to the clause that triggered the subgoal failure
-    // (The failure could potentially be a structural rule, so pointing
-    // to the clause that triggered the exception is the best we can do)
-    SourceInfo source_info = 2;
+  message FailedToSolveConstraintsError {
+    // Name of the module where the failure to solve occurred
+    ModuleName module_name = 1;
+    // The constraints that could not be solved
+    // NOTE: ALL SourceInfos are defaulted here
+    repeated Constraint constraints = 2;
+    // The initial InstanceClause that triggered the failures
+    // NOTE: The outermost SourceInfo is correct for the clause,
+    //       but all inner SourceInfos are defaulted
+    InstanceClause instance = 3;
   }
 
-  // Error that indicates the body of a tydef is malformed in some way.
+  // The body of a tydef is malformed in some way.
   // Quasi-internal; indicates that something went wrong converting from
   // a TyDef to a Pat or Exp, and cannot be ameliorated by the user.
   // (I am putting it here because it has a meaningful SourceInfo)
   message MalformedTyDefError {
-    string msg = 1;
-    // SourceInfo points at the body of the malformed type.
+    ModuleName module_name = 1;
+
+    // Ideally we'd have the Exp here but since it's not representable
+    // in protos (b/c malformed), we can't put anything meaningful here.
+
+    // SourceInfo points at malformed type definition
     SourceInfo source_info = 2;
   }
 
-  // Error that indicates an instance does not conform to one of the three
-  // basic conditions for instance validity. See the NOTE for `checkInstance`
-  // in LambdaBuffers.Compiler.TypeClassCheck.Utils. These conditions are all
-  // very straightforward and the message thoroughly explains what went wrong
-  message BadInstanceError {
-    string msg = 1;
-    // Points at the instance that triggered the violation
-    SourceInfo source_info = 2;
+  // Self explanatory
+  message OverlappingInstancesError {
+
+
+    // The constraint we were trying to solve when we detected overlap
+    Constraint constraint = 1;
+
+
+    // The overlapping rules
+    // NOTE: *ALL* of the SourceInfos here are defaulted
+    repeated InstanceClause overlaps = 2;
   }
+
+  // NOTE: If we only permit derive statements (and not user-defined
+  //       instance rules), then this set of errors is sufficient.
+  //       If we permit instance rule definitions,  we also need errors
+  //       for violations of basic conditions 1 & 2 (see Utils.hs)
+
 
   oneof typeclass_error {
     UnknownClassError unknown_class = 1;
     LocalTyRefNotFoundError ref_not_found = 2;
     SuperclassCycleError superclass_cycle = 3;
-    FailedToSolveConstraintError failed_to_solve_constraint = 4;
+    FailedToSolveConstraintsError failed_to_solve_constraints = 4;
     MalformedTyDefError malformed_ty_def = 5;
-    BadInstanceError bad_instance = 6;
+    OverlappingInstancesError overlapping_instances = 6;
   }
 
 }

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -633,6 +633,75 @@ message ProtoParseError {
   }
 }
 
+// Non-internal errors that can be thrown during
+// type class checking. Because these errors involve
+// TyClassCheck types, which cannot be converted back into
+// proto messages, the error message is constructed in the
+// TypeClassCheck modules in LambdaBuffers.Compiler
+message TypeClassError {
+  // Error which indicates that a class referred to in an instance
+  // or deriving clause does not exist. (Maybe this should be internal?)
+  message UnknownClassError {
+    string msg = 1;
+    SourceInfo source_info = 2;
+  }
+
+  // Error which indicates that the TyDef referred to by a TyRef cannot be found
+  message LocalTyRefNotFoundError {
+    string msg = 1;
+    // SourceInfo points to the clause that triggered the tyref lookup
+    SourceInfo source_info = 2;
+  }
+
+  // Error which indicates a cycle of superclasses. SourceInfo
+  // isn't particularly meaningful here - we could include the SourceInfo
+  // for each class in the cycle, but given the large amount of work
+  // required to define a LB class, this should be more than adequate
+  message SuperclassCycleError {
+    string msg  = 1;
+  }
+
+  // Error that indicates a constraint cannot be solved with
+  // the in-scope set of instance rules.
+  message FailedToSolveConstraintError {
+    string msg = 1;
+    // SourceInfo points to the clause that triggered the subgoal failure
+    // (The failure could potentially be a structural rule, so pointing
+    // to the clause that triggered the exception is the best we can do)
+    SourceInfo source_info = 2;
+  }
+
+  // Error that indicates the body of a tydef is malformed in some way.
+  // Quasi-internal; indicates that something went wrong converting from
+  // a TyDef to a Pat or Exp, and cannot be ameliorated by the user.
+  // (I am putting it here because it has a meaningful SourceInfo)
+  message MalformedTyDefError {
+    string msg = 1;
+    // SourceInfo points at the body of the malformed type.
+    SourceInfo source_info = 2;
+  }
+
+  // Error that indicates an instance does not conform to one of the three
+  // basic conditions for instance validity. See the NOTE for `checkInstance`
+  // in LambdaBuffers.Compiler.TypeClassCheck.Utils. These conditions are all
+  // very straightforward and the message thoroughly explains what went wrong
+  message BadInstanceError {
+    string msg = 1;
+    // Points at the instance that triggered the violation
+    SourceInfo source_info = 2;
+  }
+
+  oneof typeclass_error {
+    UnknownClassError unknown_class = 1;
+    LocalTyRefNotFoundError ref_not_found = 2;
+    SuperclassCycleError superclass_cycle = 3;
+    FailedToSolveConstraintError failed_to_solve_constraint = 4;
+    MalformedTyDefError malformed_ty_def = 5;
+    BadInstanceError bad_instance = 6;
+  }
+
+}
+
 // Kind checking errors.
 message KindCheckError {
 

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -633,17 +633,17 @@ message ProtoParseError {
   }
 }
 
-message TypeClassError {
+message TypeClassCheckError {
   // A class referred to in an instance
   // or deriving clause does not exist. (Maybe this should be internal?)
-  message UnknownClassError {
+  message UnboundClassError {
     // The reference that could not be resolved
     // NOTE: the class_ref contains valid/"real" source info
     TyClassRef class_ref = 1;
   }
 
   // The TyDef referred to by a TyRef cannot be found
-  message LocalTyRefNotFoundError {
+  message UnboundTyRefError {
     // NOTE: Has defaulted SourceInfo
     TyName ty_name = 1;
     // The module where the missing reference was searched for
@@ -665,7 +665,9 @@ message TypeClassError {
     // Name of the module where the failure to solve occurred
     ModuleName module_name = 1;
     // The constraints that could not be solved
-    // NOTE: ALL SourceInfos are defaulted here
+    // NOTE: Some SourceInfos are defaulted, some aren't,
+    //       there's no clear way to discern which ones are.
+    //       (I think this is a bad idea fwiw)
     repeated Constraint constraints = 2;
     // The initial InstanceClause that triggered the failures
     // NOTE: The outermost SourceInfo is correct for the clause,
@@ -673,27 +675,11 @@ message TypeClassError {
     InstanceClause instance = 3;
   }
 
-  // The body of a tydef is malformed in some way.
-  // Quasi-internal; indicates that something went wrong converting from
-  // a TyDef to a Pat or Exp, and cannot be ameliorated by the user.
-  // (I am putting it here because it has a meaningful SourceInfo)
-  message MalformedTyDefError {
-    ModuleName module_name = 1;
-
-    // Ideally we'd have the Exp here but since it's not representable
-    // in protos (b/c malformed), we can't put anything meaningful here.
-
-    // SourceInfo points at malformed type definition
-    SourceInfo source_info = 2;
-  }
-
   // Self explanatory
   message OverlappingInstancesError {
 
-
     // The constraint we were trying to solve when we detected overlap
     Constraint constraint = 1;
-
 
     // The overlapping rules
     // NOTE: *ALL* of the SourceInfos here are defaulted
@@ -707,12 +693,11 @@ message TypeClassError {
 
 
   oneof typeclass_error {
-    UnknownClassError unknown_class = 1;
-    LocalTyRefNotFoundError ref_not_found = 2;
+    UnboundClassError unknown_class = 1;
+    UnboundTyRefError ref_not_found = 2;
     SuperclassCycleError superclass_cycle = 3;
     FailedToSolveConstraintsError failed_to_solve_constraints = 4;
-    MalformedTyDefError malformed_ty_def = 5;
-    OverlappingInstancesError overlapping_instances = 6;
+    OverlappingInstancesError overlapping_instances = 5;
   }
 
 }


### PR DESCRIPTION
This is about the best I can do without attempting to rewrite the whole thing to use the ProtoCompat types (which I am fairly certain isn't possible to do in a sane manner). 

@bladyjoker You're not going to like the proto message types for the errors b/c they're basically just `(Text,SourceInfo)` but we might have to live with that unless you have a better idea of how to rewrite all of the typeclass machinery. You got your `SourceInfo` everywhere it matters, I'm not sure that I can meaningfully give you more than that. 

It should be possible to generate error messages which are frontend-agnostic enough to be meaningful independent of a particular frontend, however at the moment the errors render things into a Haskell-ish syntax. I can clean that up later, it's not important. 