### PR TITLE
Coden: LamVal and Haskell instance implementation printing

### DIFF
--- a/lambda-buffers-codegen/app/LambdaBuffers/Codegen/Cli/GenHaskell.hs
+++ b/lambda-buffers-codegen/app/LambdaBuffers/Codegen/Cli/GenHaskell.hs
@@ -21,7 +21,7 @@ gen opts = do
 
   Gen.gen
     (opts ^. common)
-    (\ci -> runPrint cfg <$> ci ^. #modules)
+    (\ci -> runPrint cfg ci <$> ci ^. #modules)
 
 readHaskellConfig :: FilePath -> IO H.Config
 readHaskellConfig f = do

--- a/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/LambdaBuffers.hs
+++ b/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/LambdaBuffers.hs
@@ -27,6 +27,7 @@ module LambdaBuffers.LambdaBuffers (ClassConstraint
                                    , VarName) where
 
 import qualified LambdaBuffers.Prelude
+import qualified PlutusTx
 import qualified Prelude
 
 data ClassConstraint = MkClassConstraint { classConstraint'class :: ClassRef
@@ -106,3 +107,43 @@ instance Prelude.Eq TyName where
   (==) = (\x0 -> (\x1 -> let MkTyName x2 = x0 in let MkTyName x3 = x1 in (((Prelude.&&) Prelude.True) (((Prelude.==) x2) x3)) ) )
 instance Prelude.Eq VarName where
   (==) = (\x0 -> (\x1 -> let MkVarName x2 = x0 in let MkVarName x3 = x1 in (((Prelude.&&) Prelude.True) (((Prelude.==) x2) x3)) ) )
+instance (PlutusTx.ToData a
+         ,PlutusTx.ToData b
+         ,PlutusTx.ToData c) => PlutusTx.ToData (Foo a b c) where
+  toBuiltinData = (Prelude..) PlutusTx.dataToBuiltinData
+                              (\x0 -> case x0 of
+                                      Foo'Bar x1 x2 x3 -> ((PlutusTx.Constr 0) [(PlutusTx.toData x1)
+                                                                               ,(PlutusTx.toData x2)
+                                                                               ,(PlutusTx.toData x3)])
+                                      Foo'Baz x4 x5 x6 -> ((PlutusTx.Constr 1) [(PlutusTx.toData x4)
+                                                                               ,(PlutusTx.toData x5)
+                                                                               ,(PlutusTx.toData x6)])
+                                      Foo'Bax x7 x8 x9 -> ((PlutusTx.Constr 2) [(PlutusTx.toData x7)
+                                                                               ,(PlutusTx.toData x8)
+                                                                               ,(PlutusTx.toData x9)]) )
+instance PlutusTx.ToData Module where
+  toBuiltinData = (Prelude..) PlutusTx.dataToBuiltinData
+                              (\x0 -> (PlutusTx.List [(PlutusTx.toData (module'name x0))
+                                                     ,(PlutusTx.toData (module'tyDefs x0))
+                                                     ,(PlutusTx.toData (module'classDefs x0))
+                                                     ,(PlutusTx.toData (module'ruleImports x0))
+                                                     ,(PlutusTx.toData (module'instanceClauses x0))
+                                                     ,(PlutusTx.toData (module'derives x0))]) )
+instance PlutusTx.ToData TyRef where
+  toBuiltinData = (Prelude..) PlutusTx.dataToBuiltinData
+                              (\x0 -> case x0 of
+                                      TyRef'Local x1 -> ((PlutusTx.Constr 0) [(PlutusTx.toData x1)])
+                                      TyRef'Foreign x2 x3 -> ((PlutusTx.Constr 1) [(PlutusTx.toData x2)
+                                                                                  ,(PlutusTx.toData x3)]) )
+instance PlutusTx.ToData ModuleName where
+  toBuiltinData = (Prelude..) PlutusTx.dataToBuiltinData
+                              (\x0 -> let MkModuleName x1 = x0 in (PlutusTx.toData x1) )
+instance PlutusTx.ToData ModuleNamePart where
+  toBuiltinData = (Prelude..) PlutusTx.dataToBuiltinData
+                              (\x0 -> let MkModuleNamePart x1 = x0 in (PlutusTx.toData x1) )
+instance PlutusTx.ToData TyName where
+  toBuiltinData = (Prelude..) PlutusTx.dataToBuiltinData
+                              (\x0 -> let MkTyName x1 = x0 in (PlutusTx.toData x1) )
+instance PlutusTx.ToData VarName where
+  toBuiltinData = (Prelude..) PlutusTx.dataToBuiltinData
+                              (\x0 -> let MkVarName x1 = x0 in (PlutusTx.toData x1) )

--- a/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/LambdaBuffers.hs
+++ b/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/LambdaBuffers.hs
@@ -9,6 +9,7 @@ module LambdaBuffers.LambdaBuffers (ClassConstraint
                                    , Derive
                                    , Field
                                    , FieldName
+                                   , Foo
                                    , InstanceClause
                                    , Kind
                                    , Module
@@ -45,6 +46,7 @@ data Constructor = MkConstructor { constructor'name :: ConstrName
 newtype Derive = MkDerive Constraint
 data Field = MkField { field'name :: FieldName, field'ty :: Ty}
 newtype FieldName = MkFieldName LambdaBuffers.Prelude.Text
+data Foo a b c = Foo'Bar a b c | Foo'Baz a b c | Foo'Bax a b c
 data InstanceClause = MkInstanceClause { instanceClause'head :: Constraint
                                        , instanceClause'body :: LambdaBuffers.Prelude.List Constraint}
 data Kind = Kind'Type  | Kind'Arrow Kind Kind
@@ -70,8 +72,22 @@ newtype TyName = MkTyName LambdaBuffers.Prelude.Text
 data TyRef = TyRef'Local TyName | TyRef'Foreign ModuleName TyName
 newtype VarName = MkVarName LambdaBuffers.Prelude.Text
 
-instance Prelude.Eq Module where
-  (==) = (\x0 -> (\x1 -> (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) Prelude.True) (((Prelude.==) (module'name x0)) (module'name x1)))) (((Prelude.==) (module'tyDefs x0)) (module'tyDefs x1)))) (((Prelude.==) (module'classDefs x0)) (module'classDefs x1)))) (((Prelude.==) (module'ruleImports x0)) (module'ruleImports x1)))) (((Prelude.==) (module'instanceClauses x0)) (module'instanceClauses x1)))) (((Prelude.==) (module'derives x0)) (module'derives x1))) ) )
+instance (Prelude.Eq a,Prelude.Eq b,Prelude.Eq c) => Prelude.Eq (Foo a
+                                                                     b
+                                                                     c) where
+  (==) = (\x0 -> (\x1 -> case x0 of
+                         Foo'Bar x2 x3 x4 -> case x1 of
+                                             Foo'Bar x5 x6 x7 -> (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) Prelude.True) (((Prelude.==) x2) x5))) (((Prelude.==) x3) x6))) (((Prelude.==) x4) x7))
+                                             Foo'Baz x8 x9 x10 -> Prelude.False
+                                             Foo'Bax x11 x12 x13 -> Prelude.False
+                         Foo'Baz x14 x15 x16 -> case x1 of
+                                                Foo'Bar x17 x18 x19 -> Prelude.False
+                                                Foo'Baz x20 x21 x22 -> (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) Prelude.True) (((Prelude.==) x14) x20))) (((Prelude.==) x15) x21))) (((Prelude.==) x16) x22))
+                                                Foo'Bax x23 x24 x25 -> Prelude.False
+                         Foo'Bax x26 x27 x28 -> case x1 of
+                                                Foo'Bar x29 x30 x31 -> Prelude.False
+                                                Foo'Baz x32 x33 x34 -> Prelude.False
+                                                Foo'Bax x35 x36 x37 -> (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) Prelude.True) (((Prelude.==) x26) x35))) (((Prelude.==) x27) x36))) (((Prelude.==) x28) x37)) ) )
 instance Prelude.Eq Module where
   (==) = (\x0 -> (\x1 -> (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) Prelude.True) (((Prelude.==) (module'name x0)) (module'name x1)))) (((Prelude.==) (module'tyDefs x0)) (module'tyDefs x1)))) (((Prelude.==) (module'classDefs x0)) (module'classDefs x1)))) (((Prelude.==) (module'ruleImports x0)) (module'ruleImports x1)))) (((Prelude.==) (module'instanceClauses x0)) (module'instanceClauses x1)))) (((Prelude.==) (module'derives x0)) (module'derives x1))) ) )
 instance Prelude.Eq TyRef where

--- a/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/LambdaBuffers.hs
+++ b/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/LambdaBuffers.hs
@@ -26,6 +26,7 @@ module LambdaBuffers.LambdaBuffers (ClassConstraint
                                    , VarName) where
 
 import qualified LambdaBuffers.Prelude
+import qualified Prelude
 
 data ClassConstraint = MkClassConstraint { classConstraint'class :: ClassRef
                                          , classConstraint'args :: LambdaBuffers.Prelude.List TyArg}
@@ -68,3 +69,24 @@ data TyDef = MkTyDef { tyDef'name :: TyName, tyDef'abs :: TyAbs}
 newtype TyName = MkTyName LambdaBuffers.Prelude.Text
 data TyRef = TyRef'Local TyName | TyRef'Foreign ModuleName TyName
 newtype VarName = MkVarName LambdaBuffers.Prelude.Text
+
+instance Prelude.Eq Module where
+  (==) = (\x0 -> (\x1 -> (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) Prelude.True) (((Prelude.==) (module'name x0)) (module'name x1)))) (((Prelude.==) (module'tyDefs x0)) (module'tyDefs x1)))) (((Prelude.==) (module'classDefs x0)) (module'classDefs x1)))) (((Prelude.==) (module'ruleImports x0)) (module'ruleImports x1)))) (((Prelude.==) (module'instanceClauses x0)) (module'instanceClauses x1)))) (((Prelude.==) (module'derives x0)) (module'derives x1))) ) )
+instance Prelude.Eq Module where
+  (==) = (\x0 -> (\x1 -> (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) (((Prelude.&&) Prelude.True) (((Prelude.==) (module'name x0)) (module'name x1)))) (((Prelude.==) (module'tyDefs x0)) (module'tyDefs x1)))) (((Prelude.==) (module'classDefs x0)) (module'classDefs x1)))) (((Prelude.==) (module'ruleImports x0)) (module'ruleImports x1)))) (((Prelude.==) (module'instanceClauses x0)) (module'instanceClauses x1)))) (((Prelude.==) (module'derives x0)) (module'derives x1))) ) )
+instance Prelude.Eq TyRef where
+  (==) = (\x0 -> (\x1 -> case x0 of
+                         TyRef'Local x2 -> case x1 of
+                                           TyRef'Local x3 -> (((Prelude.&&) Prelude.True) (((Prelude.==) x2) x3))
+                                           TyRef'Foreign x4 x5 -> Prelude.False
+                         TyRef'Foreign x6 x7 -> case x1 of
+                                                TyRef'Local x8 -> Prelude.False
+                                                TyRef'Foreign x9 x10 -> (((Prelude.&&) (((Prelude.&&) Prelude.True) (((Prelude.==) x6) x9))) (((Prelude.==) x7) x10)) ) )
+instance Prelude.Eq ModuleName where
+  (==) = (\x0 -> (\x1 -> let MkModuleName x2 = x0 in let MkModuleName x3 = x1 in (((Prelude.&&) Prelude.True) (((Prelude.==) x2) x3)) ) )
+instance Prelude.Eq ModuleNamePart where
+  (==) = (\x0 -> (\x1 -> let MkModuleNamePart x2 = x0 in let MkModuleNamePart x3 = x1 in (((Prelude.&&) Prelude.True) (((Prelude.==) x2) x3)) ) )
+instance Prelude.Eq TyName where
+  (==) = (\x0 -> (\x1 -> let MkTyName x2 = x0 in let MkTyName x3 = x1 in (((Prelude.&&) Prelude.True) (((Prelude.==) x2) x3)) ) )
+instance Prelude.Eq VarName where
+  (==) = (\x0 -> (\x1 -> let MkVarName x2 = x0 in let MkVarName x3 = x1 in (((Prelude.&&) Prelude.True) (((Prelude.==) x2) x3)) ) )

--- a/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/Plutus.hs
+++ b/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/Plutus.hs
@@ -1,0 +1,6 @@
+module LambdaBuffers.Plutus () where
+
+
+
+
+

--- a/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/Prelude.hs
+++ b/lambda-buffers-codegen/data/goldens/autogen/LambdaBuffers/Prelude.hs
@@ -44,3 +44,4 @@ type UInt16 = Data.Word.Word16
 type UInt32 = Data.Word.Word32
 type UInt64 = Data.Word.Word64
 type UInt8 = Data.Word.Word8
+

--- a/lambda-buffers-codegen/data/goldens/lambda-buffers.input.textproto
+++ b/lambda-buffers-codegen/data/goldens/lambda-buffers.input.textproto
@@ -229,6 +229,221 @@ modules {
       }
     }
   }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "PlutusData"
+          }
+          module_name {
+            parts {
+            name:
+              "Plutus"
+            }
+          }
+        }
+      }
+      args {
+        ty_app {
+          ty_func {
+            ty_ref {
+              local_ty_ref {
+                ty_name {
+                  name: "Foo"
+                }
+              }
+            }
+          }
+          ty_args {
+            ty_var {
+              var_name{name: "a"}
+            }
+          }
+          ty_args {
+            ty_var {
+              var_name{name: "b"}
+            }
+          }
+          ty_args {
+            ty_var {
+              var_name{name: "c"}
+            }
+          }
+
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "PlutusData"
+          }
+          module_name {
+            parts {
+            name:
+              "Plutus"
+            }
+          }
+        }
+      }
+      args {
+            ty_ref {
+              local_ty_ref {
+                ty_name {
+                  name: "Module"
+                }
+              }
+            }
+      }
+    }
+  }
+
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "PlutusData"
+          }
+          module_name {
+            parts {
+            name:
+              "Plutus"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "TyRef"
+            }
+          }
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "PlutusData"
+          }
+          module_name {
+            parts {
+            name:
+              "Plutus"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "ModuleName"
+            }
+          }
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "PlutusData"
+          }
+          module_name {
+            parts {
+            name:
+              "Plutus"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "ModuleNamePart"
+            }
+          }
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "PlutusData"
+          }
+          module_name {
+            parts {
+            name:
+              "Plutus"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "TyName"
+            }
+          }
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "PlutusData"
+          }
+          module_name {
+            parts {
+            name:
+              "Plutus"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "VarName"
+            }
+          }
+        }
+      }
+    }
+  }
 
   imports {
       parts {
@@ -3690,5 +3905,21 @@ modules {
     file: "goldens/good/Prelude.lbf"
     pos_from { column: 1 row: 1 }
     pos_to { column: 13 row: 37 }
+  }
+}
+modules {
+  module_name {
+    parts {
+      name: "Plutus"
+    }
+  }
+  class_defs {
+    class_name {
+      name: "PlutusData"
+    }
+    class_args {
+        arg_name { name: "a" }
+        arg_kind { kind_ref: KIND_REF_TYPE }
+    }
   }
 }

--- a/lambda-buffers-codegen/data/goldens/lambda-buffers.input.textproto
+++ b/lambda-buffers-codegen/data/goldens/lambda-buffers.input.textproto
@@ -31,17 +31,36 @@ modules {
         }
       }
       args {
+        ty_app {
+          ty_func {
             ty_ref {
               local_ty_ref {
                 ty_name {
-                  name: "Module"
+                  name: "Foo"
                 }
               }
             }
+          }
+          ty_args {
+            ty_var {
+              var_name{name: "a"}
+            }
+          }
+          ty_args {
+            ty_var {
+              var_name{name: "b"}
+            }
+          }
+          ty_args {
+            ty_var {
+              var_name{name: "c"}
+            }
+          }
+
+        }
       }
     }
   }
-
   derives {
     constraint {
       class_ref {
@@ -215,6 +234,118 @@ modules {
       parts {
         name: "Prelude"
       }
+  }
+  type_defs {
+ty_name{name : "Foo"} ty_abs {
+    ty_args {
+      arg_name{name : "a"} arg_kind {
+      kind_ref:
+        KIND_REF_TYPE
+      }
+    }
+    ty_args {
+      arg_name{name : "b"} arg_kind {
+      kind_ref:
+        KIND_REF_TYPE
+      }
+    }
+    ty_args {
+      arg_name{name : "c"} arg_kind {
+      kind_ref:
+        KIND_REF_TYPE
+      }
+    }
+
+    ty_body {
+      sum {
+        constructors {
+          constr_name{name : "Bar"} product {
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "a"
+                }
+              }
+            }
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "b"
+                }
+              }
+            }
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "c"
+                }
+              }
+            }
+          }
+        }
+        constructors {
+          constr_name{name : "Baz"} product {
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "a"
+                }
+              }
+            }
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "b"
+                }
+              }
+            }
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "c"
+                }
+              }
+            }
+          }
+        }
+        constructors {
+          constr_name{name : "Bax"} product {
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "a"
+                }
+              }
+            }
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "b"
+                }
+              }
+            }
+            fields {
+              ty_var {
+                var_name {
+                name:
+                  "c"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   }
   type_defs {
     ty_name {

--- a/lambda-buffers-codegen/data/goldens/lambda-buffers.input.textproto
+++ b/lambda-buffers-codegen/data/goldens/lambda-buffers.input.textproto
@@ -14,6 +14,208 @@ modules {
       pos_to { column: 21 row: 1 }
     }
   }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "Eq"
+          }
+          module_name {
+            parts {
+            name:
+              "Prelude"
+            }
+          }
+        }
+      }
+      args {
+            ty_ref {
+              local_ty_ref {
+                ty_name {
+                  name: "Module"
+                }
+              }
+            }
+      }
+    }
+  }
+
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "Eq"
+          }
+          module_name {
+            parts {
+            name:
+              "Prelude"
+            }
+          }
+        }
+      }
+      args {
+            ty_ref {
+              local_ty_ref {
+                ty_name {
+                  name: "Module"
+                }
+              }
+            }
+      }
+    }
+  }
+
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "Eq"
+          }
+          module_name {
+            parts {
+            name:
+              "Prelude"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "TyRef"
+            }
+          }
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "Eq"
+          }
+          module_name {
+            parts {
+            name:
+              "Prelude"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "ModuleName"
+            }
+          }
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "Eq"
+          }
+          module_name {
+            parts {
+            name:
+              "Prelude"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "ModuleNamePart"
+            }
+          }
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "Eq"
+          }
+          module_name {
+            parts {
+            name:
+              "Prelude"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "TyName"
+            }
+          }
+        }
+      }
+    }
+  }
+  derives {
+    constraint {
+      class_ref {
+        foreign_class_ref {
+          class_name {
+          name:
+            "Eq"
+          }
+          module_name {
+            parts {
+            name:
+              "Prelude"
+            }
+          }
+        }
+      }
+      args {
+        ty_ref {
+          local_ty_ref {
+            ty_name {
+            name:
+              "VarName"
+            }
+          }
+        }
+      }
+    }
+  }
+
+  imports {
+      parts {
+        name: "Prelude"
+      }
+  }
   type_defs {
     ty_name {
       name: "Kind"
@@ -2961,6 +3163,35 @@ modules {
       file: "goldens/good/Prelude.lbf"
       pos_from { column: 8 row: 1 }
       pos_to { column: 15 row: 1 }
+    }
+  }
+  instances {
+    head: {
+      class_ref {
+        local_class_ref {
+          class_name {
+            name: "Eq"
+          }
+        }
+      }
+      args {
+        ty_ref {
+        local_ty_ref {
+          ty_name {
+            name: "Text"
+          }
+        }
+        }
+      }
+    }
+  }
+  class_defs {
+    class_name {
+      name: "Eq"
+    }
+    class_args {
+        arg_name { name: "a" }
+        arg_kind { kind_ref: KIND_REF_TYPE }
     }
   }
   type_defs {

--- a/lambda-buffers-codegen/data/goldens/runtime/LambdaBuffers/Runtime/Haskell.hs
+++ b/lambda-buffers-codegen/data/goldens/runtime/LambdaBuffers/Runtime/Haskell.hs
@@ -1,0 +1,3 @@
+module LambdaBuffers.Runtime.Haskell (List) where
+
+type List a = [a]

--- a/lambda-buffers-codegen/data/haskell.json
+++ b/lambda-buffers-codegen/data/haskell.json
@@ -97,11 +97,6 @@
                 "plutus-tx",
                 "PlutusTx",
                 "ToData"
-            ],
-            [
-                "plutus-tx",
-                "PlutusTx",
-                "FromData"
             ]
         ],
         "Prelude.Eq": [

--- a/lambda-buffers-codegen/data/haskell.json
+++ b/lambda-buffers-codegen/data/haskell.json
@@ -1,94 +1,127 @@
 {
-  "opaquesConfig": {
-    "Prelude.Bool": [
-      "base",
-      "Prelude",
-      "Bool"
-    ],
-    "Prelude.Integer": [
-      "base",
-      "Prelude",
-      "Integer"
-    ],
-    "Prelude.Int8": [
-      "base",
-      "Data.Int",
-      "Int8"
-    ],
-    "Prelude.Int16": [
-      "base",
-      "Data.Int",
-      "Int16"
-    ],
-    "Prelude.Int32": [
-      "base",
-      "Data.Int",
-      "Int32"
-    ],
-    "Prelude.Int64": [
-      "base",
-      "Data.Int",
-      "Int64"
-    ],
-    "Prelude.UInt8": [
-      "base",
-      "Data.Word",
-      "Word8"
-    ],
-    "Prelude.UInt16": [
-      "base",
-      "Data.Word",
-      "Word16"
-    ],
-    "Prelude.UInt32": [
-      "base",
-      "Data.Word",
-      "Word32"
-    ],
-    "Prelude.UInt64": [
-      "base",
-      "Data.Word",
-      "Word64"
-    ],
-    "Prelude.Char": [
-      "base",
-      "Prelude",
-      "Char"
-    ],
-    "Prelude.Text": [
-      "text",
-      "Data.Text",
-      "Text"
-    ],
-    "Prelude.Bytes": [
-      "bytestring",
-      "Data.ByteString",
-      "ByteString"
-    ],
-    "Prelude.Maybe": [
-      "base",
-      "Prelude",
-      "Maybe"
-    ],
-    "Prelude.Either": [
-      "base",
-      "Prelude",
-      "Either"
-    ],
-    "Prelude.List": [
-      "lb-haskell-runtime",
-      "LambdaBuffers.Runtime.Haskell",
-      "List"
-    ],
-    "Prelude.Set": [
-      "containers",
-      "Data.Set",
-      "Set"
-    ],
-    "Prelude.Map": [
-      "containers",
-      "Data.Map",
-      "Map"
-    ]
-  }
+    "opaquesConfig": {
+        "Prelude.Map": [
+            "containers",
+            "Data.Map",
+            "Map"
+        ],
+        "Prelude.Set": [
+            "containers",
+            "Data.Set",
+            "Set"
+        ],
+        "Prelude.List": [
+            "lb-haskell-runtime",
+            "LambdaBuffers.Runtime.Haskell",
+            "List"
+        ],
+        "Prelude.Either": [
+            "base",
+            "Prelude",
+            "Either"
+        ],
+        "Prelude.Maybe": [
+            "base",
+            "Prelude",
+            "Maybe"
+        ],
+        "Prelude.Bytes": [
+            "bytestring",
+            "Data.ByteString",
+            "ByteString"
+        ],
+        "Prelude.Text": [
+            "text",
+            "Data.Text",
+            "Text"
+        ],
+        "Prelude.Char": [
+            "base",
+            "Prelude",
+            "Char"
+        ],
+        "Prelude.UInt64": [
+            "base",
+            "Data.Word",
+            "Word64"
+        ],
+        "Prelude.UInt32": [
+            "base",
+            "Data.Word",
+            "Word32"
+        ],
+        "Prelude.UInt16": [
+            "base",
+            "Data.Word",
+            "Word16"
+        ],
+        "Prelude.UInt8": [
+            "base",
+            "Data.Word",
+            "Word8"
+        ],
+        "Prelude.Int64": [
+            "base",
+            "Data.Int",
+            "Int64"
+        ],
+        "Prelude.Int32": [
+            "base",
+            "Data.Int",
+            "Int32"
+        ],
+        "Prelude.Int16": [
+            "base",
+            "Data.Int",
+            "Int16"
+        ],
+        "Prelude.Int8": [
+            "base",
+            "Data.Int",
+            "Int8"
+        ],
+        "Prelude.Integer": [
+            "base",
+            "Prelude",
+            "Integer"
+        ],
+        "Prelude.Bool": [
+            "base",
+            "Prelude",
+            "Bool"
+        ]
+    },
+    "classesConfig": {
+        "Plutus.PlutusData": [
+            [
+                "plutus-tx",
+                "PlutusTx",
+                "ToData"
+            ],
+            [
+                "plutus-tx",
+                "PlutusTx",
+                "FromData"
+            ]
+        ],
+        "Prelude.Eq": [
+            [
+                "base",
+                "Prelude",
+                "Eq"
+            ]
+        ],
+        "Prelude.Json": [
+            [
+                "aeson",
+                "Data.Aeson",
+                "ToJSON"
+            ],
+            [
+                "aeson",
+                "Data.Aeson",
+                "FromJSON"
+            ]
+        ]
+    }
 }

--- a/lambda-buffers-codegen/lambda-buffers-codegen.cabal
+++ b/lambda-buffers-codegen/lambda-buffers-codegen.cabal
@@ -114,7 +114,16 @@ library
     LambdaBuffers.Codegen.Haskell
     LambdaBuffers.Codegen.Haskell.Config
     LambdaBuffers.Codegen.Haskell.Print
+    LambdaBuffers.Codegen.Haskell.Print.Derive
+    LambdaBuffers.Codegen.Haskell.Print.InstanceDef
+    LambdaBuffers.Codegen.Haskell.Print.LamVal
+    LambdaBuffers.Codegen.Haskell.Print.Monad
+    LambdaBuffers.Codegen.Haskell.Print.Names
+    LambdaBuffers.Codegen.Haskell.Print.TyDef
     LambdaBuffers.Codegen.Haskell.Syntax
+    LambdaBuffers.Codegen.LamVal
+    LambdaBuffers.Codegen.LamVal.Derive
+    LambdaBuffers.Codegen.LamVal.Eq
     LambdaBuffers.Codegen.Print
 
 executable lbg

--- a/lambda-buffers-codegen/lambda-buffers-codegen.cabal
+++ b/lambda-buffers-codegen/lambda-buffers-codegen.cabal
@@ -124,6 +124,7 @@ library
     LambdaBuffers.Codegen.LamVal
     LambdaBuffers.Codegen.LamVal.Derive
     LambdaBuffers.Codegen.LamVal.Eq
+    LambdaBuffers.Codegen.LamVal.PlutusData
     LambdaBuffers.Codegen.Print
 
 executable lbg

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Config.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Config.hs
@@ -1,6 +1,6 @@
 module LambdaBuffers.Codegen.Config (Config (..), opaques, classes) where
 
-import Control.Lens (makeLenses, view, (^.), (^..))
+import Control.Lens (makeLenses, view)
 import Data.Aeson (FromJSON, ToJSON, parseJSON)
 import Data.Aeson.Types (ToJSON (toJSON))
 import Data.Default (Default (def))
@@ -12,6 +12,7 @@ import Data.Text qualified as Text
 import GHC.Generics (Generic)
 import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Utils qualified as PC
 
 data Config o c = MkConfig
   { _opaques :: Map PC.QTyName o
@@ -21,25 +22,38 @@ data Config o c = MkConfig
 
 makeLenses 'MkConfig
 
-newtype JsonConfig o = MkJsonConfig
+data JsonConfig o c = MkJsonConfig
   { opaquesConfig :: Map Text o
+  , classesConfig :: Map Text c
   }
   deriving stock (Eq, Ord, Show, Generic)
 
-qTyNameToText :: PC.QTyName -> Text
-qTyNameToText (mn, tyn) = Text.intercalate "." $ PC.withInfoLess mn (\mn' -> mn' ^. #parts ^.. traverse . #name) <> [PC.withInfoLess tyn (view #name)]
+moduleNameToText :: PC.InfoLess PC.ModuleName -> Text
+moduleNameToText = Text.pack . show . (`PC.withInfoLess` PC.prettyModuleName)
 
-qTyNameFromText :: MonadFail m => Text -> m PC.QTyName
-qTyNameFromText qtyn =
-  let xs = Text.split (== '.') qtyn
+qTyNameToText :: PC.QTyName -> Text
+qTyNameToText (mn, tyn) = moduleNameToText mn <> "." <> PC.withInfoLess tyn (view #name)
+
+qClassNameToText :: PC.QClassName -> Text
+qClassNameToText (mn, cn) = moduleNameToText mn <> "." <> PC.withInfoLess cn (view #name)
+
+qNameFromText :: MonadFail m => Text -> m (PC.InfoLess PC.ModuleName, Text)
+qNameFromText qn =
+  let xs = Text.split (== '.') qn
    in case List.reverse xs of
-        [] -> fail "Got an empty text but wanted a qualified LambdaBuffers type name (<module name>.<type name>)"
-        [x] -> fail $ "Got a single text " <> show x <> " but wanted a qualified LambdaBuffers type name (<module name>.<type name>)"
-        (tyn : mn) ->
+        [] -> fail "Got an empty text but wanted a qualified LambdaBuffers name (<module name>.<type name|class name>)"
+        [x] -> fail $ "Got a single text " <> show x <> " but wanted a qualified LambdaBuffers name (<module name>.<type name|class name>)"
+        (n : mn) ->
           return
             ( PC.mkInfoLess $ PC.ModuleName [PC.ModuleNamePart p def | p <- List.reverse mn] def
-            , PC.mkInfoLess $ PC.TyName tyn def
+            , n
             )
+
+qTyNameFromText :: MonadFail m => Text -> m PC.QTyName
+qTyNameFromText qtyn = qNameFromText qtyn >>= \(mn, n) -> return (mn, PC.mkInfoLess (PC.TyName n def))
+
+qClassNameFromText :: MonadFail m => Text -> m PC.QClassName
+qClassNameFromText qcn = qNameFromText qcn >>= \(mn, n) -> return (mn, PC.mkInfoLess (PC.ClassName n def))
 
 toOpaquesConfig :: Map PC.QTyName o -> Map Text o
 toOpaquesConfig = Map.mapKeys qTyNameToText
@@ -47,17 +61,23 @@ toOpaquesConfig = Map.mapKeys qTyNameToText
 fromOpaquesConfig :: MonadFail m => Map Text o -> m (Map PC.QTyName o)
 fromOpaquesConfig opqs = Map.fromList <$> traverse (\(ltyn, htyn) -> (,) <$> qTyNameFromText ltyn <*> pure htyn) (Map.toList opqs)
 
-toJsonConfig :: Config o c -> JsonConfig o
-toJsonConfig (MkConfig opqs _) = MkJsonConfig (toOpaquesConfig opqs)
+toClassesConfig :: Map PC.QClassName o -> Map Text o
+toClassesConfig = Map.mapKeys qClassNameToText
 
-fromJsonConfig :: MonadFail m => JsonConfig o -> m (Config o c)
-fromJsonConfig (MkJsonConfig opqs) = MkConfig <$> fromOpaquesConfig opqs <*> pure mempty
+fromClassesConfig :: MonadFail m => Map Text o -> m (Map PC.QClassName o)
+fromClassesConfig opqs = Map.fromList <$> traverse (\(ltyn, htyn) -> (,) <$> qClassNameFromText ltyn <*> pure htyn) (Map.toList opqs)
 
-instance ToJSON o => ToJSON (JsonConfig o)
-instance FromJSON o => FromJSON (JsonConfig o)
+toJsonConfig :: Config o c -> JsonConfig o c
+toJsonConfig (MkConfig opqs cls) = MkJsonConfig (toOpaquesConfig opqs) (toClassesConfig cls)
 
-instance ToJSON o => ToJSON (Config o c) where
+fromJsonConfig :: MonadFail m => JsonConfig o c -> m (Config o c)
+fromJsonConfig (MkJsonConfig opqs cls) = MkConfig <$> fromOpaquesConfig opqs <*> fromClassesConfig cls
+
+instance (ToJSON o, ToJSON c) => ToJSON (JsonConfig o c)
+instance (FromJSON o, FromJSON c) => FromJSON (JsonConfig o c)
+
+instance (ToJSON o, ToJSON c) => ToJSON (Config o c) where
   toJSON = toJSON . toJsonConfig
 
-instance FromJSON o => FromJSON (Config o c) where
+instance (FromJSON o, FromJSON c) => FromJSON (Config o c) where
   parseJSON v = parseJSON v >>= fromJsonConfig

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell.hs
@@ -14,8 +14,8 @@ import Prettyprinter (defaultLayoutOptions, layoutPretty)
 import Prettyprinter.Render.Text (renderStrict)
 import Proto.Compiler qualified as P
 
-runPrint :: Haskell.Config -> PC.Module -> Either P.CompilerError (FilePath, Text)
-runPrint cfg m = case runCheck cfg m of
+runPrint :: Haskell.Config -> PC.CompilerInput -> PC.Module -> Either P.CompilerError (FilePath, Text)
+runPrint cfg ci m = case runCheck cfg ci m of
   Left err -> Left err
   Right ctx -> case Print.runPrint ctx Haskell.printModule of
     Left err -> Left err

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Config.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Config.hs
@@ -6,10 +6,13 @@ import Data.Aeson (FromJSON, ToJSON)
 import LambdaBuffers.Codegen.Config qualified as Config
 import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
 
-type Config = Config.Config H.QTyName H.QClassName
+type Config = Config.Config H.QTyName [H.QClassName]
 
 instance ToJSON H.TyName
 instance FromJSON H.TyName
+
+instance ToJSON H.ClassName
+instance FromJSON H.ClassName
 
 instance ToJSON H.ModuleName
 instance FromJSON H.ModuleName

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print.hs
@@ -1,208 +1,117 @@
-module LambdaBuffers.Codegen.Haskell.Print (printModule) where
+{- | `Print.MonadPrint` implementation for the Haskell backend.
+
+ The monad is instantiated with `H.QTyName` which are qualified Haskell type
+ names referring to `Opaque` type imports. It's also instantiated with
+ `[H.QClassName]` which denotes the qualified Haskell class names to import.
+ Note that a single LambdaBuffers 'class' can be unpacked into several related
+ Haskell classes and that's why it's a list of qualified Haskell class names.
+-}
+module LambdaBuffers.Codegen.Haskell.Print (MonadPrint, printModule) where
 
 import Control.Lens (view, (^.))
 import Control.Monad.Error.Class (MonadError (throwError))
 import Control.Monad.Reader.Class (ask, asks)
-import Data.Char qualified as Char
-import Data.Foldable (Foldable (toList))
+import Data.Default (Default (def))
+import Data.Foldable (Foldable (toList), foldrM)
+import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Map.Ordered qualified as OMap
 import Data.Set (Set)
 import Data.Set qualified as Set
+import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Traversable (for)
-import LambdaBuffers.Codegen.Config (opaques)
-import LambdaBuffers.Codegen.Haskell.Syntax (fromLbModuleName)
+import LambdaBuffers.Codegen.Haskell.Print.Derive (printDeriveEq)
+import LambdaBuffers.Codegen.Haskell.Print.InstanceDef (printInstanceDefs)
+import LambdaBuffers.Codegen.Haskell.Print.Monad (MonadPrint)
+import LambdaBuffers.Codegen.Haskell.Print.Names (printModName, printModName', printTyName)
+import LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyDef)
 import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
-import LambdaBuffers.Codegen.Print (ctxConfig, ctxModule)
 import LambdaBuffers.Codegen.Print qualified as Print
+import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
 import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
-import Prettyprinter (Doc, Pretty (pretty), align, colon, comma, dot, encloseSep, equals, group, lbrace, lparen, parens, pipe, rbrace, rparen, sep, space, squote, vsep, (<+>))
+import Prettyprinter (Doc, Pretty (pretty), align, comma, encloseSep, group, lparen, rparen, space, vsep, (<+>))
 
-type MonadPrint m = Print.MonadPrint H.QTyName H.QClassName m
-
-printModule :: MonadPrint m => m (Doc a)
+printModule :: MonadPrint m => m (Doc ann)
 printModule = do
-  Print.MkContext m lbTyImps opTyImps tyExps _cfg <- ask
+  Print.MkContext _ci m lbTyImps opTyImps classImps ruleImps tyExps _cfg <- ask
   tyDefDocs <- for (toList $ m ^. #typeDefs) printTyDef
+  (instDocs, valImps) <- printInstances
   return $
     align . vsep $
       [ printModuleHeader (m ^. #moduleName) tyExps
       , mempty
-      , printImports lbTyImps opTyImps
+      , printImports lbTyImps opTyImps classImps ruleImps valImps
       , mempty
       , vsep tyDefDocs -- TODO(bladyjoker): Add additional line in between TyDefs.
+      , mempty
+      , vsep instDocs -- TODO(bladyjoker): Add additional line in between implementations.
       ]
 
-printModuleHeader :: PC.ModuleName -> Set (PC.InfoLess PC.TyName) -> Doc a
+classImplementations ::
+  Map
+    PC.QClassName
+    ( PC.ModuleName ->
+      PC.TyDefs ->
+      Map H.QClassName (Doc ann -> Doc ann) ->
+      PC.Ty ->
+      Either Text (Doc ann, Set H.QValName)
+    )
+classImplementations =
+  Map.fromList
+    [
+      ( (PC.mkInfoLess $ PC.ModuleName [PC.ModuleNamePart "Prelude" def] def, PC.mkInfoLess $ PC.ClassName "Eq" def)
+      , printDeriveEq
+      )
+    ]
+
+printInstances :: MonadPrint m => m ([Doc ann], Set H.QValName)
+printInstances = do
+  ci <- asks (view Print.ctxCompilerInput)
+  m <- asks (view Print.ctxModule)
+  let iTyDefs = PC.indexTyDefs ci
+  foldrM
+    ( \d (instDocs, valImps) -> do
+        (instDoc', valImps') <- printDerive iTyDefs d
+        return (instDoc' : instDocs, valImps `Set.union` valImps')
+    )
+    (mempty, Set.empty)
+    (toList $ m ^. #derives)
+
+-- TODO(bladyjoker): This is too complicated.
+printDerive :: MonadPrint m => PC.TyDefs -> PC.Derive -> m (Doc ann, Set H.QValName)
+printDerive iTyDefs d = do
+  mn <- asks (view $ Print.ctxModule . #moduleName)
+  let qcn = PC.qualifyClassRef mn (d ^. #constraint . #classRef)
+  case Map.lookup qcn classImplementations of
+    Nothing -> throwError (d ^. #constraint . #sourceInfo, "TODO(bladyjoker): Missing capability to print " <> (Text.pack . show $ qcn))
+    Just implPrinter -> do
+      mkInstanceDocs <- printInstanceDefs d
+      case implPrinter mn iTyDefs mkInstanceDocs (d ^. #constraint . #argument) of
+        Left err -> throwError (d ^. #constraint . #sourceInfo, "Failed printing the implementation\n" <> err)
+        Right (instanceDefsDoc, valImps) -> return (instanceDefsDoc, valImps)
+
+printModuleHeader :: PC.ModuleName -> Set (PC.InfoLess PC.TyName) -> Doc ann
 printModuleHeader mn exports =
   let typeExportsDoc = align $ group $ encloseSep lparen rparen (comma <> space) ((`PC.withInfoLess` printTyName) <$> toList exports)
    in "module" <+> printModName mn <+> typeExportsDoc <+> "where"
 
-printImports :: Set PC.QTyName -> Set H.QTyName -> Doc a
-printImports lbTyImports hsTyImports =
-  let groupedLbImports = Set.fromList [PC.withInfoLess mn id | (mn, _tn) <- toList lbTyImports]
-      lbImportDocs = (\mn -> "import qualified" <+> printModName mn) <$> toList groupedLbImports
+-- TODO(bladyjoker): Collect package dependencies.
+printImports :: Set PC.QTyName -> Set H.QTyName -> Set [H.QClassName] -> Set (PC.InfoLess PC.ModuleName) -> Set H.QValName -> Doc ann
+printImports lbTyImports hsTyImports classImps ruleImps valImps =
+  let groupedLbImports =
+        Set.fromList [mn | (mn, _tn) <- toList lbTyImports]
+          `Set.union` ruleImps
+      lbImportDocs = importQualified . printModName' <$> toList groupedLbImports
 
-      groupedHsImports = Set.fromList [mn | (_cbl, mn, _tn) <- toList hsTyImports]
-      hsImportDocs = (\(H.MkModuleName mn) -> "import qualified" <+> pretty mn) <$> toList groupedHsImports
+      groupedHsImports =
+        Set.fromList [mn | (_cbl, mn, _tn) <- toList hsTyImports]
+          `Set.union` Set.fromList [mn | cImps <- toList classImps, (_, mn, _) <- cImps]
+          `Set.union` Set.fromList [mn | (_, mn, _) <- toList valImps]
+      hsImportDocs = (\(H.MkModuleName mn) -> importQualified $ pretty mn) <$> toList groupedHsImports
 
       importsDoc = vsep $ lbImportDocs ++ hsImportDocs
    in importsDoc
-
-printModName :: PC.ModuleName -> Doc a
-printModName mn = let H.MkModuleName hmn = fromLbModuleName mn in pretty hmn
-
-printHsQTyName :: H.QTyName -> Doc a
-printHsQTyName (_, H.MkModuleName hsModName, H.MkTyName hsTyName) = pretty hsModName <> dot <> pretty hsTyName
-
-{- | Prints the type definition.
-
-sum Foo a b = MkFoo a | MkBar b
-opaque Maybe a
-
-translates to
-
-data Foo a b = Foo'MkFoo a | Foo'MkBar b
-type Maybe a = Prelude.Maybe a
--}
-printTyDef :: MonadPrint m => PC.TyDef -> m (Doc a)
-printTyDef (PC.TyDef tyN tyabs _) = do
-  (kw, absDoc) <- printTyAbs tyN tyabs
-  return $ group $ kw <+> printTyName tyN <+> absDoc
-
-{- | Prints the type abstraction.
-
-For the above examples it prints
-
-a b = Foo'MkFoo a | Foo'MkBar b
-a = Prelude.Maybe a
--}
-printTyAbs :: MonadPrint m => PC.TyName -> PC.TyAbs -> m (Doc a, Doc a)
-printTyAbs tyN (PC.TyAbs args body _) = do
-  let argsDoc = if OMap.empty == args then mempty else encloseSep mempty space space (printTyArg <$> toList args)
-  (kw, bodyDoc) <- printTyBody tyN (toList args) body
-  return (kw, group $ argsDoc <> align (equals <+> bodyDoc))
-
-{- | Prints the type body.
-
-For the above examples it prints
-
-Foo'MkFoo a | Foo'MkBar b
-Prelude.Maybe a
-
-TODO(bladyjoker): Revisit empty records and prods.
--}
-printTyBody :: MonadPrint m => PC.TyName -> [PC.TyArg] -> PC.TyBody -> m (Doc a, Doc a)
-printTyBody tyN _ (PC.SumI s) = ("data",) <$> printTyBodySum tyN s
-printTyBody tyN _ (PC.ProductI p@(PC.Product fields _)) = case toList fields of
-  [] -> return ("data", printMkCtor tyN)
-  [_] -> return ("newtype", printMkCtor tyN <+> printProd p)
-  _ -> return ("data", printMkCtor tyN <+> printProd p)
-printTyBody tyN _ (PC.RecordI r@(PC.Record fields _)) = case toList fields of
-  [] -> return ("data", printMkCtor tyN)
-  [_] -> printRec tyN r >>= \recDoc -> return ("newtype", printMkCtor tyN <+> recDoc)
-  _ -> printRec tyN r >>= \recDoc -> return ("data", printMkCtor tyN <+> recDoc)
-printTyBody tyN args (PC.OpaqueI si) = do
-  opqs <- asks (view $ ctxConfig . opaques)
-  mn <- asks (view $ ctxModule . #moduleName)
-  case Map.lookup (PC.mkInfoLess mn, PC.mkInfoLess tyN) opqs of
-    Nothing -> throwError (si, "Internal error: Should have an Opaque configured for " <> (Text.pack . show $ tyN))
-    Just hqtyn -> return ("type", printHsQTyName hqtyn <> if null args then mempty else space <> sep (printVarName . view #argName <$> args))
-
-printTyArg :: forall {a}. PC.TyArg -> Doc a
-printTyArg (PC.TyArg vn _ _) = printVarName vn
-
-printTyBodySum :: MonadPrint m => PC.TyName -> PC.Sum -> m (Doc a)
-printTyBodySum tyN (PC.Sum ctors _) = do
-  let ctorDocs = printCtor tyN <$> toList ctors
-  return $
-    group $
-      if null ctors
-        then mempty
-        else align $ encloseSep mempty mempty (space <> pipe <> space) ctorDocs -- TODO(bladyjoker): Make it align on the ConstrName.
-
-printCtor :: PC.TyName -> PC.Constructor -> Doc a
-printCtor tyN (PC.Constructor ctorName prod) =
-  let ctorNDoc = printCtorName tyN ctorName
-      prodDoc = printProd prod
-   in group $ ctorNDoc <+> prodDoc -- TODO(bladyjoker): Adds extra space when empty.
-
-{- | Translate LambdaBuffer sum constructor names into Haskell sum constructor names.
- sum Sum = Foo Int | Bar String
- translates to
- data Sum = Sum'Foo Int | Sum'Bar String
--}
-printCtorName :: PC.TyName -> PC.ConstrName -> Doc a
-printCtorName tyN (PC.ConstrName n _) = printTyName tyN <> squote <> pretty n
-
-printRec :: MonadPrint m => PC.TyName -> PC.Record -> m (Doc a)
-printRec tyN (PC.Record fields _) = do
-  if null fields
-    then return mempty
-    else do
-      fieldDocs <- for (toList fields) (printField tyN)
-      return $ group $ align $ encloseSep (lbrace <> space) rbrace (comma <> space) fieldDocs
-
-printProd :: PC.Product -> Doc a
-printProd (PC.Product fields _) = do
-  if null fields
-    then mempty
-    else align $ sep (printTyInner <$> fields)
-
-printMkCtor :: PC.TyName -> Doc a
-printMkCtor tyN = "Mk" <> printTyName tyN
-
-printField :: MonadPrint m => PC.TyName -> PC.Field -> m (Doc a)
-printField tyN (PC.Field fn ty) = do
-  fnDoc <- printFieldName tyN fn
-  let tyDoc = printTyTopLevel ty
-  return $ fnDoc <+> colon <> colon <+> tyDoc
-
-{- | Translate LambdaBuffer record field names into Haskell record field names
- rec Rec = { foo :: Int, bar :: String }
- translates to
- data Rec = MkRec { rec'foo :: Int, rec'bar :: String }
--}
-printFieldName :: MonadPrint m => PC.TyName -> PC.FieldName -> m (Doc a)
-printFieldName tyN (PC.FieldName n _) = do
-  prefix <- case Text.uncons (tyN ^. #name) of
-    Nothing -> throwError (tyN ^. #sourceInfo, "TODO(bladyjoker): Internal error: Empty type name")
-    Just (h, t) -> return $ Text.cons (Char.toLower h) t
-  return $ pretty prefix <> squote <> pretty n
-
-printTyInner :: PC.Ty -> Doc a
-printTyInner (PC.TyVarI v) = printTyVar v
-printTyInner (PC.TyRefI r) = printTyRef r
-printTyInner (PC.TyAppI a) = printTyAppInner a
-
-printTyAppInner :: PC.TyApp -> Doc a
-printTyAppInner (PC.TyApp f args _) =
-  let fDoc = printTyInner f
-      argsDoc = printTyInner <$> args
-   in group $ parens $ fDoc <+> align (sep argsDoc)
-
-printTyTopLevel :: PC.Ty -> Doc a
-printTyTopLevel (PC.TyVarI v) = printTyVar v
-printTyTopLevel (PC.TyRefI r) = printTyRef r
-printTyTopLevel (PC.TyAppI a) = printTyAppTopLevel a
-
-printTyAppTopLevel :: PC.TyApp -> Doc a
-printTyAppTopLevel (PC.TyApp f args _) =
-  let fDoc = printTyInner f
-      argsDoc = printTyInner <$> args
-   in group $ fDoc <+> align (sep argsDoc)
-
-printTyRef :: PC.TyRef -> Doc a
-printTyRef (PC.LocalI (PC.LocalRef tn _)) = group $ printTyName tn
-printTyRef (PC.ForeignI fr) = let (_, H.MkModuleName hmn, H.MkTyName htn) = H.fromLbForeignRef fr in pretty hmn <> dot <> pretty htn
-
-printTyVar :: PC.TyVar -> Doc a
-printTyVar (PC.TyVar vn) = printVarName vn
-
-printVarName :: PC.VarName -> Doc a
-printVarName (PC.VarName n _) = pretty n
-
-printTyName :: PC.TyName -> Doc a
-printTyName (PC.TyName n _) = pretty n
+  where
+    importQualified :: Doc ann -> Doc ann
+    importQualified mnDoc = "import qualified" <+> mnDoc

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/Derive.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/Derive.hs
@@ -1,0 +1,44 @@
+module LambdaBuffers.Codegen.Haskell.Print.Derive (printDeriveEq) where
+
+import Data.Foldable (Foldable (toList))
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as Text
+import LambdaBuffers.Codegen.Haskell.Print.LamVal (printImplementation)
+import LambdaBuffers.Codegen.Haskell.Print.Names (printHsValName)
+import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
+import LambdaBuffers.Codegen.LamVal qualified as LV
+import LambdaBuffers.Codegen.LamVal.Eq (deriveEqImpl)
+import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+import Prettyprinter (Doc, equals, vsep, (<+>))
+
+lvBuiltins :: Map LV.ValueName (H.CabalPackageName, H.ModuleName, H.ValueName)
+lvBuiltins =
+  Map.fromList
+    [ ("eq", (H.MkCabalPackageName "base", H.MkModuleName "Prelude", H.MkValueName "=="))
+    , ("and", (H.MkCabalPackageName "base", H.MkModuleName "Prelude", H.MkValueName "&&"))
+    , ("true", (H.MkCabalPackageName "base", H.MkModuleName "Prelude", H.MkValueName "True"))
+    , ("false", (H.MkCabalPackageName "base", H.MkModuleName "Prelude", H.MkValueName "False"))
+    ]
+
+eqClassMethodName :: H.ValueName
+eqClassMethodName = H.MkValueName "=="
+
+-- TODO: Handle errors properly.
+printDeriveEq :: PC.ModuleName -> PC.TyDefs -> Map H.QClassName (Doc ann -> Doc ann) -> PC.Ty -> Either Text (Doc ann, Set H.QValName)
+printDeriveEq mn iTyDefs mkInstanceDocs ty =
+  case deriveEqImpl mn iTyDefs ty of
+    Left err -> Left $ Text.pack err
+    Right valE ->
+      case printImplementation lvBuiltins valE of
+        Left err -> Left $ Text.pack $ show err
+        Right implDoc ->
+          let instanceDocs = ($ printValueDef eqClassMethodName implDoc) <$> mkInstanceDocs
+           in Right (vsep (toList instanceDocs), Set.fromList . toList $ lvBuiltins)
+
+printValueDef :: H.ValueName -> Doc ann -> Doc ann
+printValueDef valName valDoc = printHsValName valName <+> equals <+> valDoc

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/Derive.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/Derive.hs
@@ -1,4 +1,4 @@
-module LambdaBuffers.Codegen.Haskell.Print.Derive (printDeriveEq) where
+module LambdaBuffers.Codegen.Haskell.Print.Derive (printDeriveEq, printDeriveToPlutusData) where
 
 import Data.Foldable (Foldable (toList))
 import Data.Map (Map)
@@ -8,16 +8,17 @@ import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as Text
 import LambdaBuffers.Codegen.Haskell.Print.LamVal (printImplementation)
-import LambdaBuffers.Codegen.Haskell.Print.Names (printHsValName)
+import LambdaBuffers.Codegen.Haskell.Print.Names (printHsQValName, printHsValName)
 import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
 import LambdaBuffers.Codegen.LamVal qualified as LV
 import LambdaBuffers.Codegen.LamVal.Eq (deriveEqImpl)
+import LambdaBuffers.Codegen.LamVal.PlutusData (deriveToPlutusDataImpl)
 import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
-import Prettyprinter (Doc, equals, vsep, (<+>))
+import Prettyprinter (Doc, align, equals, group, sep, (<+>))
 
-lvBuiltins :: Map LV.ValueName (H.CabalPackageName, H.ModuleName, H.ValueName)
-lvBuiltins =
+lvEqBuiltins :: Map LV.ValueName (H.CabalPackageName, H.ModuleName, H.ValueName)
+lvEqBuiltins =
   Map.fromList
     [ ("eq", (H.MkCabalPackageName "base", H.MkModuleName "Prelude", H.MkValueName "=="))
     , ("and", (H.MkCabalPackageName "base", H.MkModuleName "Prelude", H.MkValueName "&&"))
@@ -29,16 +30,53 @@ eqClassMethodName :: H.ValueName
 eqClassMethodName = H.MkValueName "=="
 
 -- TODO: Handle errors properly.
-printDeriveEq :: PC.ModuleName -> PC.TyDefs -> Map H.QClassName (Doc ann -> Doc ann) -> PC.Ty -> Either Text (Doc ann, Set H.QValName)
-printDeriveEq mn iTyDefs mkInstanceDocs ty =
+printDeriveEq :: PC.ModuleName -> PC.TyDefs -> (Doc ann -> Doc ann) -> PC.Ty -> Either Text (Doc ann, Set H.QValName)
+printDeriveEq mn iTyDefs mkInstanceDoc ty =
   case deriveEqImpl mn iTyDefs ty of
     Left err -> Left $ Text.pack err
     Right valE ->
-      case printImplementation lvBuiltins valE of
+      case printImplementation lvEqBuiltins valE of
         Left err -> Left $ Text.pack $ show err
         Right implDoc ->
-          let instanceDocs = ($ printValueDef eqClassMethodName implDoc) <$> mkInstanceDocs
-           in Right (vsep (toList instanceDocs), Set.fromList . toList $ lvBuiltins)
+          let instanceDoc = mkInstanceDoc (printValueDef eqClassMethodName implDoc)
+           in Right (instanceDoc, Set.fromList . toList $ lvEqBuiltins)
+
+lvPlutusDataBuiltins :: Map LV.ValueName H.QValName
+lvPlutusDataBuiltins =
+  Map.fromList
+    [ ("toPlutusData", (H.MkCabalPackageName "plutus-tx", H.MkModuleName "PlutusTx", H.MkValueName "toData"))
+    , ("integerData", (H.MkCabalPackageName "plutus-tx", H.MkModuleName "PlutusTx", H.MkValueName "I"))
+    , ("constrData", (H.MkCabalPackageName "plutus-tx", H.MkModuleName "PlutusTx", H.MkValueName "Constr"))
+    , ("listData", (H.MkCabalPackageName "plutus-tx", H.MkModuleName "PlutusTx", H.MkValueName "List"))
+    ]
+
+dataToBuiltinDataRef :: H.QValName
+dataToBuiltinDataRef = (H.MkCabalPackageName "plutus-tx", H.MkModuleName "PlutusTx", H.MkValueName "dataToBuiltinData")
+
+dotOp :: H.QValName
+dotOp = (H.MkCabalPackageName "base", H.MkModuleName "Prelude", H.MkValueName ".")
+
+toPlutusDataClassMethodName :: H.ValueName
+toPlutusDataClassMethodName = H.MkValueName "toBuiltinData"
+
+-- TODO: Handle errors properly.
+printDeriveToPlutusData :: PC.ModuleName -> PC.TyDefs -> (Doc ann -> Doc ann) -> PC.Ty -> Either Text (Doc ann, Set H.QValName)
+printDeriveToPlutusData mn iTyDefs mkInstanceDoc ty =
+  case deriveToPlutusDataImpl mn iTyDefs ty of
+    Left err -> Left $ Text.pack err
+    Right valE ->
+      case printImplementation lvPlutusDataBuiltins valE of
+        Left err -> Left $ Text.pack $ show err
+        Right implDoc ->
+          let dataToBuiltinDataDoc = printValueApp dotOp [printHsQValName dataToBuiltinDataRef, implDoc]
+              instanceDoc = mkInstanceDoc (printValueDef toPlutusDataClassMethodName dataToBuiltinDataDoc)
+           in Right
+                ( instanceDoc
+                , Set.insert dataToBuiltinDataRef $ Set.fromList . toList $ lvPlutusDataBuiltins
+                )
 
 printValueDef :: H.ValueName -> Doc ann -> Doc ann
 printValueDef valName valDoc = printHsValName valName <+> equals <+> valDoc
+
+printValueApp :: H.QValName -> [Doc ann] -> Doc ann
+printValueApp fVal aDocs = align . group $ (printHsQValName fVal <+> (align . group . sep $ aDocs))

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/InstanceDef.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/InstanceDef.hs
@@ -11,7 +11,7 @@ import Data.Set qualified as Set
 import LambdaBuffers.Codegen.Config qualified as C
 import LambdaBuffers.Codegen.Haskell.Print.Monad (MonadPrint)
 import LambdaBuffers.Codegen.Haskell.Print.Names (printHsQClassName)
-import LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyTopLevel)
+import LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyInner)
 import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
 import LambdaBuffers.Codegen.Print (ctxConfig, ctxModule)
 import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
@@ -39,7 +39,7 @@ printInstanceDef hsQClassName ty =
 printConstraint :: H.QClassName -> PC.Ty -> Doc ann
 printConstraint qcn ty =
   let crefDoc = printHsQClassName qcn
-      tyDoc = printTyTopLevel ty
+      tyDoc = printTyInner ty
    in crefDoc <+> tyDoc
 
 collectTyVars :: PC.Ty -> [PC.Ty]

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/InstanceDef.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/InstanceDef.hs
@@ -1,40 +1,26 @@
-module LambdaBuffers.Codegen.Haskell.Print.InstanceDef (printInstanceDefs) where
+module LambdaBuffers.Codegen.Haskell.Print.InstanceDef (printInstanceDef) where
 
-import Control.Lens (view, (^.))
-import Control.Monad.Error.Class (MonadError (throwError))
-import Control.Monad.RWS.Class (asks)
+import Control.Lens (view)
 import Data.Foldable (Foldable (toList))
-import Data.Map (Map)
-import Data.Map qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
-import LambdaBuffers.Codegen.Config qualified as C
-import LambdaBuffers.Codegen.Haskell.Print.Monad (MonadPrint)
 import LambdaBuffers.Codegen.Haskell.Print.Names (printHsQClassName)
 import LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyInner)
 import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
-import LambdaBuffers.Codegen.Print (ctxConfig, ctxModule)
-import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
 import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
-import Prettyprinter (Doc, comma, encloseSep, hardline, lparen, rparen, space, (<+>))
-
-printInstanceDefs :: MonadPrint m => PC.Derive -> m (Map H.QClassName (Doc ann -> Doc ann))
-printInstanceDefs drv = do
-  mn <- asks (view $ ctxModule . #moduleName)
-  classes <- asks (view $ ctxConfig . C.classes)
-  hsQClassNames <- case Map.lookup (PC.qualifyClassRef mn (drv ^. #constraint . #classRef)) classes of
-    Nothing -> throwError (drv ^. #constraint . #sourceInfo, "TODO(bladyjoker): Internal error: Missing classes mapping")
-    Just hsQClassNames -> return hsQClassNames
-  return $ Map.fromList ((\hsQcn -> (hsQcn, printInstanceDef hsQcn (drv ^. #constraint . #argument))) <$> hsQClassNames)
+import Prettyprinter (Doc, align, comma, encloseSep, group, hardline, lparen, rparen, space, (<+>))
 
 printInstanceDef :: H.QClassName -> PC.Ty -> (Doc ann -> Doc ann)
 printInstanceDef hsQClassName ty =
   let headDoc = printConstraint hsQClassName ty
-      contextDocs = printConstraint hsQClassName <$> collectTyVars ty
-   in case toList contextDocs of
+      freeVars = collectTyVars ty
+   in case freeVars of
         [] -> \implDoc -> "instance" <+> headDoc <+> "where" <> hardline <> space <> space <> implDoc
-        ctxDocs -> \implDoc -> "instance" <+> encloseSep lparen rparen comma ctxDocs <+> "=>" <+> headDoc <+> "where" <> hardline <> space <> space <> implDoc
+        _ -> \implDoc -> "instance" <+> printInstanceContext hsQClassName freeVars <+> "=>" <+> headDoc <+> "where" <> hardline <> space <> space <> implDoc
+
+printInstanceContext :: H.QClassName -> [PC.Ty] -> Doc ann
+printInstanceContext hsQClassName tys = align . group $ encloseSep lparen rparen comma (printConstraint hsQClassName <$> tys)
 
 printConstraint :: H.QClassName -> PC.Ty -> Doc ann
 printConstraint qcn ty =

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/InstanceDef.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/InstanceDef.hs
@@ -1,0 +1,54 @@
+module LambdaBuffers.Codegen.Haskell.Print.InstanceDef (printInstanceDefs) where
+
+import Control.Lens (view, (^.))
+import Control.Monad.Error.Class (MonadError (throwError))
+import Control.Monad.RWS.Class (asks)
+import Data.Foldable (Foldable (toList))
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
+import LambdaBuffers.Codegen.Config qualified as C
+import LambdaBuffers.Codegen.Haskell.Print.Monad (MonadPrint)
+import LambdaBuffers.Codegen.Haskell.Print.Names (printHsQClassName)
+import LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyTopLevel)
+import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
+import LambdaBuffers.Codegen.Print (ctxConfig, ctxModule)
+import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+import Prettyprinter (Doc, comma, encloseSep, hardline, lparen, rparen, space, (<+>))
+
+printInstanceDefs :: MonadPrint m => PC.Derive -> m (Map H.QClassName (Doc ann -> Doc ann))
+printInstanceDefs drv = do
+  mn <- asks (view $ ctxModule . #moduleName)
+  classes <- asks (view $ ctxConfig . C.classes)
+  hsQClassNames <- case Map.lookup (PC.qualifyClassRef mn (drv ^. #constraint . #classRef)) classes of
+    Nothing -> throwError (drv ^. #constraint . #sourceInfo, "TODO(bladyjoker): Internal error: Missing classes mapping")
+    Just hsQClassNames -> return hsQClassNames
+  return $ Map.fromList ((\hsQcn -> (hsQcn, printInstanceDef hsQcn (drv ^. #constraint . #argument))) <$> hsQClassNames)
+
+printInstanceDef :: H.QClassName -> PC.Ty -> (Doc ann -> Doc ann)
+printInstanceDef hsQClassName ty =
+  let headDoc = printConstraint hsQClassName ty
+      contextDocs = printConstraint hsQClassName <$> collectTyVars ty
+   in case toList contextDocs of
+        [] -> \implDoc -> "instance" <+> headDoc <+> "where" <> hardline <> space <> space <> implDoc
+        ctxDocs -> \implDoc -> "instance" <+> encloseSep lparen rparen comma ctxDocs <+> "=>" <+> headDoc <+> "where" <> hardline <> space <> space <> implDoc
+
+printConstraint :: H.QClassName -> PC.Ty -> Doc ann
+printConstraint qcn ty =
+  let crefDoc = printHsQClassName qcn
+      tyDoc = printTyTopLevel ty
+   in crefDoc <+> tyDoc
+
+collectTyVars :: PC.Ty -> [PC.Ty]
+collectTyVars = fmap (`PC.withInfoLess` (PC.TyVarI . PC.TyVar)) . toList . collectVars
+
+collectVars :: PC.Ty -> Set (PC.InfoLess PC.VarName)
+collectVars = collectVars' mempty
+
+collectVars' :: Set (PC.InfoLess PC.VarName) -> PC.Ty -> Set (PC.InfoLess PC.VarName)
+collectVars' collected (PC.TyVarI tv) = Set.insert (PC.mkInfoLess . view #varName $ tv) collected
+collectVars' collected (PC.TyAppI (PC.TyApp _ args _)) = collected `Set.union` (Set.unions . fmap collectVars $ args)
+collectVars' collected _ = collected

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/LamVal.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/LamVal.hs
@@ -1,0 +1,151 @@
+module LambdaBuffers.Codegen.Haskell.Print.LamVal (printValueE, printImplementation) where
+
+import Control.Monad.Error.Class (MonadError (throwError))
+import Control.Monad.Except (runExcept)
+import Control.Monad.RWS (RWST (runRWST))
+import Control.Monad.RWS.Class (MonadRWS)
+import Control.Monad.Reader (asks)
+import Control.Monad.State.Class (gets, modify)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Map.Ordered qualified as OMap
+import Data.Traversable (for)
+import LambdaBuffers.Codegen.Haskell.Print.Names (printCtorName, printFieldName, printHsQValName, printMkCtor)
+import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
+import LambdaBuffers.Codegen.LamVal qualified as LV
+import LambdaBuffers.Compiler.ProtoCompat.Eval qualified as E
+import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+import Prettyprinter (Doc, Pretty (pretty), align, enclose, equals, group, hsep, line, lparen, rparen, vsep, (<+>))
+
+newtype PrintRead = MkPrintRead
+  { builtins :: Map LV.ValueName H.QValName
+  }
+  deriving stock (Show)
+
+newtype PrintState = MkPrintState
+  { currentVar :: Int
+  }
+  deriving stock (Eq, Ord, Show)
+
+newtype PrintCommand = ImportInstance H.ModuleName
+  deriving stock (Eq, Ord)
+  deriving stock (Show)
+
+type PrintErr = String
+
+type MonadPrint m = (MonadRWS PrintRead () PrintState m, MonadError PrintErr m)
+
+printImplementation :: Map LV.ValueName H.QValName -> LV.ValueE -> Either PrintErr (Doc ann)
+printImplementation lamValBuiltins valE =
+  let p = runExcept $ runRWST (printValueE valE) (MkPrintRead lamValBuiltins) (MkPrintState 0)
+   in case p of
+        Left err -> Left err
+        Right (doc, _, _) -> Right doc
+
+printCtorCase :: MonadPrint m => PC.QTyName -> ((LV.Ctor, [LV.ValueE]) -> LV.ValueE) -> LV.Ctor -> m (Doc ann)
+printCtorCase (_, tyn) ctorCont ctor@(ctorN, fields) = do
+  args <- for fields (const freshArg)
+  argDocs <- for args printValueE
+  let body = ctorCont (ctor, args)
+  bodyDoc <- printValueE body
+  let ctorNameDoc = PC.withInfoLess tyn (PC.withInfoLess ctorN . printCtorName)
+  return $ group $ ctorNameDoc <+> hsep argDocs <+> "->" <+> group bodyDoc
+
+printCaseE :: MonadPrint m => (PC.QTyName, LV.Sum) -> LV.ValueE -> ((LV.Ctor, [LV.ValueE]) -> LV.ValueE) -> m (Doc ann)
+printCaseE (qtyN, sumTy) caseVal ctorCont = do
+  caseValDoc <- printValueE caseVal
+  ctorCaseDocs <-
+    vsep
+      <$> for
+        (OMap.assocs sumTy)
+        ( \(cn, ty) -> case ty of -- TODO(bladyjoker): Cleanup by refactoring E.Ty.
+            E.TyProduct fields _ -> printCtorCase qtyN ctorCont (cn, fields)
+            _ -> throwError "TODO: Internal error, got a non-product in Sum."
+        )
+  return $ align $ "case" <+> caseValDoc <+> "of" <> line <> ctorCaseDocs
+
+printLamE :: MonadPrint m => (LV.ValueE -> LV.ValueE) -> m (Doc ann)
+printLamE lamVal = do
+  arg <- freshArg
+  bodyDoc <- printValueE (lamVal arg)
+  argDoc <- printValueE arg
+  return $ lparen <> "\\" <> argDoc <+> "->" <+> bodyDoc <+> rparen
+
+printAppE :: MonadPrint m => LV.ValueE -> LV.ValueE -> m (Doc ann)
+printAppE funVal argVal = do
+  funDoc <- printValueE funVal
+  argDoc <- printValueE argVal
+  return $ enclose lparen rparen $ funDoc <+> argDoc
+
+{- | Prints a record field accessor expression on a `ValueE` of type `Field`'.
+
+ Given a LambdaBuffers module:
+   module Foo
+
+   record Foo a b = { foo : a, bar : b}
+
+  `FieldE` on a field named `foo` of a record value `x` of type `Foo a b` translates into:
+
+   foo'foo x
+-}
+printFieldE :: MonadPrint m => (PC.QTyName, PC.InfoLess PC.FieldName) -> LV.ValueE -> m (Doc ann)
+printFieldE ((_, tyn), fieldName) recVal = do
+  recDoc <- printValueE recVal
+  let mayFnDoc = PC.withInfoLess tyn (PC.withInfoLess fieldName . printFieldName)
+  case mayFnDoc of
+    Nothing -> throwError $ "TODO(bladyjoker): Internal error: Failed print a `FieldName` in Haskell implementation printer " <> show fieldName
+    Just fnDoc -> return $ enclose lparen rparen (fnDoc <+> recDoc)
+
+{- | Prints a `let` expression on a `ValueE` of type `Product`.
+
+ Given a LambdaBuffers module:
+   module Foo
+
+   prod Foo a b = String a b
+
+ `LetE` on `Foo a b` translates into:
+
+   let MkFoo x1 x2 x3 = <letVal> in <letCont>
+-}
+printLetE :: MonadPrint m => (PC.QTyName, LV.Product, LV.ValueE) -> ([LV.ValueE] -> LV.ValueE) -> m (Doc ann)
+printLetE ((_, tyN), fields, letVal) letCont = do
+  letValDoc <- printValueE letVal
+  args <- for fields (const freshArg)
+  argDocs <- for args printValueE
+  let bodyVal = letCont args
+  bodyDoc <- printValueE bodyVal
+  let prodCtorDoc = PC.withInfoLess tyN printMkCtor
+  return $ "let" <+> prodCtorDoc <+> hsep argDocs <+> equals <+> letValDoc <+> "in" <+> bodyDoc
+
+printValueE :: MonadPrint m => LV.ValueE -> m (Doc ann)
+printValueE (LV.RefE ref) = resolveRef ref
+printValueE (LV.CaseE sumTy caseVal ctorCont) = printCaseE sumTy caseVal ctorCont
+printValueE (LV.LamE lamVal) = printLamE lamVal
+printValueE (LV.AppE funVal argVal) = printAppE funVal argVal
+printValueE (LV.VarE v) = return $ pretty v
+printValueE (LV.FieldE fieldName recVal) = printFieldE fieldName recVal
+printValueE (LV.LetE letVal letCont) = printLetE letVal letCont
+
+freshArg :: MonadPrint m => m LV.ValueE
+freshArg = do
+  i <- gets currentVar
+  modify (\(MkPrintState s) -> MkPrintState $ s + 1)
+  return $ LV.VarE $ "x" <> show i
+
+{- | Resolves a `Ref` to a value reference in the target language.
+ Resolves a `LV.Ref` which is a reference to a LamVal 'builtin', to the equivalent in the target language.
+ If the `LV.Ref` is polymorphic like `eq @Int` or `eq @(Maybe a)` or `eq @(List Int)`,
+ then lookup the implementation in the context and error if it's not there (TODO).
+
+ NOTE(bladyjoker): Currently, this is assuming all the implementations are imported.
+ TODO(bladyjoker): Output all necessary implementations from the Compiler and report on missing.
+-}
+resolveRef :: MonadPrint m => LV.Ref -> m (Doc ann)
+resolveRef (mayTy, refName) = do
+  bs <- asks builtins
+  case Map.lookup refName bs of
+    Nothing -> throwError $ "TODO(bladyjoker): LamVal builtin mapping for " <> show refName <> " not configured."
+    Just hqValName -> case mayTy of
+      Nothing -> return $ printHsQValName hqValName
+      Just _ty -> return $ printHsQValName hqValName -- TODO(bladyjoker): Add a TypeApplication notation?

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/LamVal.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/LamVal.hs
@@ -16,7 +16,7 @@ import LambdaBuffers.Codegen.LamVal qualified as LV
 import LambdaBuffers.Compiler.ProtoCompat.Eval qualified as E
 import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
 import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
-import Prettyprinter (Doc, Pretty (pretty), align, enclose, equals, group, hsep, line, lparen, rparen, vsep, (<+>))
+import Prettyprinter (Doc, Pretty (pretty), align, comma, enclose, encloseSep, equals, group, hsep, lbracket, line, lparen, rbracket, rparen, vsep, (<+>))
 
 newtype PrintRead = MkPrintRead
   { builtins :: Map LV.ValueName H.QValName
@@ -119,6 +119,9 @@ printLetE ((_, tyN), fields, letVal) letCont = do
   return $ "let" <+> prodCtorDoc <+> hsep argDocs <+> equals <+> letValDoc <+> "in" <+> bodyDoc
 
 printValueE :: MonadPrint m => LV.ValueE -> m (Doc ann)
+printValueE (LV.ErrorE err) = throwError $ "TODO(bladyjoker): LamVal error builtin was called " <> err
+printValueE (LV.IntE i) = return $ pretty i
+printValueE (LV.ListE vals) = align . group . encloseSep lbracket rbracket comma <$> (printValueE `traverse` vals)
 printValueE (LV.RefE ref) = resolveRef ref
 printValueE (LV.CaseE sumTy caseVal ctorCont) = printCaseE sumTy caseVal ctorCont
 printValueE (LV.LamE lamVal) = printLamE lamVal

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/Monad.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/Monad.hs
@@ -1,0 +1,6 @@
+module LambdaBuffers.Codegen.Haskell.Print.Monad (MonadPrint) where
+
+import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
+import LambdaBuffers.Codegen.Print qualified as Print
+
+type MonadPrint m = Print.MonadPrint H.QTyName [H.QClassName] m

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/Names.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/Names.hs
@@ -1,0 +1,69 @@
+module LambdaBuffers.Codegen.Haskell.Print.Names (printHsQTyName, printCtorName, printFieldName, printVarName, printTyName, printMkCtor, printModName, printModName', printHsQValName, printHsClassMethodName, printHsQClassName, printHsValName) where
+
+import Control.Lens ((^.))
+import Data.Char qualified as Char
+import Data.Text qualified as Text
+import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
+import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+import Prettyprinter (Doc, Pretty (pretty), dot, enclose, lparen, rparen, squote)
+
+printModName' :: PC.InfoLess PC.ModuleName -> Doc ann
+printModName' = (`PC.withInfoLess` printModName)
+
+printModName :: PC.ModuleName -> Doc ann
+printModName mn = let H.MkModuleName hmn = H.fromLbModuleName mn in pretty hmn
+
+printHsQTyName :: H.QTyName -> Doc ann
+printHsQTyName (_, H.MkModuleName hsModName, H.MkTyName hsTyName) = pretty hsModName <> dot <> pretty hsTyName
+
+printHsQClassName :: H.QClassName -> Doc ann
+printHsQClassName (_, H.MkModuleName hsModName, H.MkClassName hsClassName) = pretty hsModName <> dot <> pretty hsClassName
+
+printHsQValName :: H.QValName -> Doc ann
+printHsQValName (_, H.MkModuleName hsModName, H.MkValueName hsValName) = case Text.uncons hsValName of
+  Nothing -> "TODO(bladyjoker): Got an empty Haskell value name"
+  Just (c, _) | Char.isAlpha c -> pretty hsModName <> dot <> pretty hsValName
+  _ -> enclose lparen rparen $ pretty hsModName <> dot <> pretty hsValName
+
+printHsValName :: H.ValueName -> Doc ann
+printHsValName (H.MkValueName hsValName) = case Text.uncons hsValName of
+  Nothing -> "TODO(bladyjoker): Got an empty Haskell value name"
+  Just (c, _) | Char.isAlpha c -> pretty hsValName
+  _ -> enclose lparen rparen $ pretty hsValName
+
+{- | Print the Haskell class method name (ie. (==), toJSON etc.).
+ This doesn't require a qualified print as it's treated special, we just need to
+ import the class and the class methods are made available in the scope.
+-}
+printHsClassMethodName :: H.QValName -> Doc ann
+printHsClassMethodName (_, _, H.MkValueName hsValName) = pretty hsValName
+
+{- | Translate LambdaBuffer sum constructor names into Haskell sum constructor names.
+ sum Sum = Foo Int | Bar String
+ translates to
+ data Sum = Sum'Foo Int | Sum'Bar String
+-}
+printCtorName :: PC.TyName -> PC.ConstrName -> Doc ann
+printCtorName tyN (PC.ConstrName n _) = printTyName tyN <> squote <> pretty n
+
+printMkCtor :: PC.TyName -> Doc ann
+printMkCtor tyN = "Mk" <> printTyName tyN
+
+{- | Translate LambdaBuffer record field names into Haskell record field names
+ rec Rec = { foo :: Int, bar :: String }
+ translates to
+ data Rec = MkRec { rec'foo :: Int, rec'bar :: String }
+-}
+printFieldName :: PC.TyName -> PC.FieldName -> Maybe (Doc ann)
+printFieldName tyN (PC.FieldName n _) = do
+  prefix <- case Text.uncons (tyN ^. #name) of
+    Nothing -> Nothing
+    Just (h, t) -> return $ Text.cons (Char.toLower h) t
+  return $ pretty prefix <> squote <> pretty n
+
+printVarName :: PC.VarName -> Doc ann
+printVarName (PC.VarName n _) = pretty n
+
+printTyName :: PC.TyName -> Doc ann
+printTyName (PC.TyName n _) = pretty n

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/TyDef.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/TyDef.hs
@@ -1,0 +1,141 @@
+module LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyDef, printTyTopLevel) where
+
+import Control.Lens (view, (^.))
+import Control.Monad.Error.Class (MonadError (throwError))
+import Control.Monad.Reader.Class (asks)
+import Data.Foldable (Foldable (toList))
+import Data.Map qualified as Map
+import Data.Map.Ordered qualified as OMap
+import Data.Text qualified as Text
+import Data.Traversable (for)
+import LambdaBuffers.Codegen.Config (opaques)
+import LambdaBuffers.Codegen.Haskell.Print.Monad (MonadPrint)
+import LambdaBuffers.Codegen.Haskell.Print.Names (printCtorName, printFieldName, printHsQTyName, printMkCtor, printTyName, printVarName)
+import LambdaBuffers.Codegen.Haskell.Syntax qualified as H
+import LambdaBuffers.Codegen.Print qualified as Print
+import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+import Prettyprinter (Doc, Pretty (pretty), align, colon, comma, dot, encloseSep, equals, group, lbrace, parens, pipe, rbrace, sep, space, (<+>))
+
+{- | Prints the type definition.
+
+sum Foo a b = MkFoo a | MkBar b
+opaque Maybe a
+
+translates to
+
+data Foo a b = Foo'MkFoo a | Foo'MkBar b
+type Maybe a = Prelude.Maybe a
+-}
+printTyDef :: MonadPrint m => PC.TyDef -> m (Doc ann)
+printTyDef (PC.TyDef tyN tyabs _) = do
+  (kw, absDoc) <- printTyAbs tyN tyabs
+  return $ group $ kw <+> printTyName tyN <+> absDoc
+
+{- | Prints the type abstraction.
+
+For the above examples it prints
+
+a b = Foo'MkFoo a | Foo'MkBar b
+a = Prelude.Maybe a
+-}
+printTyAbs :: MonadPrint m => PC.TyName -> PC.TyAbs -> m (Doc ann, Doc ann)
+printTyAbs tyN (PC.TyAbs args body _) = do
+  let argsDoc = if OMap.empty == args then mempty else encloseSep mempty space space (printTyArg <$> toList args)
+  (kw, bodyDoc) <- printTyBody tyN (toList args) body
+  return (kw, group $ argsDoc <> align (equals <+> bodyDoc))
+
+{- | Prints the type body.
+
+For the above examples it prints
+
+Foo'MkFoo a | Foo'MkBar b
+Prelude.Maybe a
+
+TODO(bladyjoker): Revisit empty records and prods.
+-}
+printTyBody :: MonadPrint m => PC.TyName -> [PC.TyArg] -> PC.TyBody -> m (Doc ann, Doc ann)
+printTyBody tyN _ (PC.SumI s) = ("data",) <$> printSum tyN s
+printTyBody tyN _ (PC.ProductI p@(PC.Product fields _)) = case toList fields of
+  [] -> return ("data", printMkCtor tyN)
+  [_] -> return ("newtype", printMkCtor tyN <+> printProd p)
+  _ -> return ("data", printMkCtor tyN <+> printProd p)
+printTyBody tyN _ (PC.RecordI r@(PC.Record fields _)) = case toList fields of
+  [] -> return ("data", printMkCtor tyN)
+  [_] -> printRec tyN r >>= \recDoc -> return ("newtype", printMkCtor tyN <+> recDoc)
+  _ -> printRec tyN r >>= \recDoc -> return ("data", printMkCtor tyN <+> recDoc)
+printTyBody tyN args (PC.OpaqueI si) = do
+  opqs <- asks (view $ Print.ctxConfig . opaques)
+  mn <- asks (view $ Print.ctxModule . #moduleName)
+  case Map.lookup (PC.mkInfoLess mn, PC.mkInfoLess tyN) opqs of
+    Nothing -> throwError (si, "Internal error: Should have an Opaque configured for " <> (Text.pack . show $ tyN))
+    Just hqtyn -> return ("type", printHsQTyName hqtyn <> if null args then mempty else space <> sep (printVarName . view #argName <$> args))
+
+printTyArg :: PC.TyArg -> Doc ann
+printTyArg (PC.TyArg vn _ _) = printVarName vn
+
+printSum :: MonadPrint m => PC.TyName -> PC.Sum -> m (Doc ann)
+printSum tyN (PC.Sum ctors _) = do
+  let ctorDocs = printCtor tyN <$> toList ctors
+  return $
+    group $
+      if null ctors
+        then mempty
+        else align $ encloseSep mempty mempty (space <> pipe <> space) ctorDocs -- TODO(bladyjoker): Make it align on the ConstrName.
+
+printCtor :: PC.TyName -> PC.Constructor -> Doc ann
+printCtor tyN (PC.Constructor ctorName prod) =
+  let ctorNDoc = printCtorName tyN ctorName
+      prodDoc = printProd prod
+   in group $ ctorNDoc <+> prodDoc -- TODO(bladyjoker): Adds extra space when empty.
+
+printRec :: MonadPrint m => PC.TyName -> PC.Record -> m (Doc ann)
+printRec tyN (PC.Record fields _) = do
+  if null fields
+    then return mempty
+    else do
+      fieldDocs <- for (toList fields) (printField tyN)
+      return $ group $ align $ encloseSep (lbrace <> space) rbrace (comma <> space) fieldDocs
+
+printProd :: PC.Product -> Doc ann
+printProd (PC.Product fields _) = do
+  if null fields
+    then mempty
+    else align $ sep (printTyInner <$> fields)
+
+printField :: MonadPrint m => PC.TyName -> PC.Field -> m (Doc ann)
+printField tyN f@(PC.Field fn ty) = do
+  fnDoc <- case printFieldName tyN fn of
+    Nothing -> throwError (fn ^. #sourceInfo, "TODO(bladyjoker): Internal error: Failed printing `FieldName` for field\n" <> Text.pack (show (tyN, f)))
+    Just fnDoc -> return fnDoc
+  let tyDoc = printTyTopLevel ty
+  return $ fnDoc <+> colon <> colon <+> tyDoc
+
+printTyInner :: PC.Ty -> Doc ann
+printTyInner (PC.TyVarI v) = printTyVar v
+printTyInner (PC.TyRefI r) = printTyRef r
+printTyInner (PC.TyAppI a) = printTyAppInner a
+
+printTyAppInner :: PC.TyApp -> Doc ann
+printTyAppInner (PC.TyApp f args _) =
+  let fDoc = printTyInner f
+      argsDoc = printTyInner <$> args
+   in group $ parens $ fDoc <+> align (sep argsDoc)
+
+printTyTopLevel :: PC.Ty -> Doc ann
+printTyTopLevel (PC.TyVarI v) = printTyVar v
+printTyTopLevel (PC.TyRefI r) = printTyRef r
+printTyTopLevel (PC.TyAppI a) = printTyAppTopLevel a
+
+printTyAppTopLevel :: PC.TyApp -> Doc ann
+printTyAppTopLevel (PC.TyApp f args _) =
+  let fDoc = printTyInner f
+      argsDoc = printTyInner <$> args
+   in group $ fDoc <+> align (sep argsDoc)
+
+printTyRef :: PC.TyRef -> Doc ann
+printTyRef (PC.LocalI (PC.LocalRef tn _)) = group $ printTyName tn
+printTyRef (PC.ForeignI fr) = let (_, H.MkModuleName hmn, H.MkTyName htn) = H.fromLbForeignRef fr in pretty hmn <> dot <> pretty htn
+
+printTyVar :: PC.TyVar -> Doc ann
+printTyVar (PC.TyVar vn) = printVarName vn

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/TyDef.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/TyDef.hs
@@ -1,4 +1,4 @@
-module LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyDef, printTyTopLevel) where
+module LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyDef, printTyInner) where
 
 import Control.Lens (view, (^.))
 import Control.Monad.Error.Class (MonadError (throwError))

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Syntax.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Syntax.hs
@@ -1,4 +1,4 @@
-module LambdaBuffers.Codegen.Haskell.Syntax (QTyName, QClassName, CabalPackageName (..), ModuleName (..), TyName (..), ClassName (..), FunctionName (..), fromLbModuleName, cabalFromLbModuleName, fromLbTyName, fromLbForeignRef, filepathFromModuleName) where
+module LambdaBuffers.Codegen.Haskell.Syntax (QTyName, QClassName, QValName, CabalPackageName (..), ModuleName (..), TyName (..), ClassName (..), ValueName (..), fromLbModuleName, cabalFromLbModuleName, fromLbTyName, fromLbForeignRef, filepathFromModuleName) where
 
 import Control.Lens ((^.))
 import Data.Text (Text)
@@ -8,12 +8,13 @@ import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
 
 type QTyName = (CabalPackageName, ModuleName, TyName)
 type QClassName = (CabalPackageName, ModuleName, ClassName)
+type QValName = (CabalPackageName, ModuleName, ValueName)
 
 newtype CabalPackageName = MkCabalPackageName Text deriving stock (Eq, Ord, Show, Generic)
 newtype ModuleName = MkModuleName Text deriving stock (Eq, Ord, Show, Generic)
 newtype TyName = MkTyName Text deriving stock (Eq, Ord, Show, Generic)
 newtype ClassName = MkClassName Text deriving stock (Eq, Ord, Show, Generic)
-newtype FunctionName = MkFunctionName Text deriving stock (Eq, Ord, Show, Generic)
+newtype ValueName = MkValueName Text deriving stock (Eq, Ord, Show, Generic)
 
 fromLbTyName :: PC.TyName -> TyName
 fromLbTyName tn = MkTyName $ tn ^. #name

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal.hs
@@ -1,0 +1,73 @@
+module LambdaBuffers.Codegen.LamVal (
+  ValueE (..),
+  ValueName,
+  Ref,
+  letE,
+  fieldE,
+  lamE,
+  (@),
+  caseE,
+  refE,
+  SumImpl,
+  ProductImpl,
+  RecordImpl,
+  Record,
+  Product,
+  Sum,
+  Field,
+  Ctor,
+) where
+
+import Data.Map.Ordered (OMap)
+import LambdaBuffers.Compiler.ProtoCompat.Eval qualified as E
+import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+
+-- | A name for a value.
+type ValueName = String
+
+-- | A value reference that may be parametrized on a `E.Ty`.
+type Ref = (Maybe E.Ty, ValueName)
+
+-- | Simple HOAS encoding of a little lambda calculus language.
+data ValueE where
+  LamE :: (ValueE -> ValueE) -> ValueE
+  AppE :: ValueE -> ValueE -> ValueE
+  RefE :: Ref -> ValueE
+  VarE :: String -> ValueE
+  CaseE :: (PC.QTyName, Sum) -> ValueE -> ((Ctor, [ValueE]) -> ValueE) -> ValueE
+  FieldE :: (PC.QTyName, PC.InfoLess PC.FieldName) -> ValueE -> ValueE
+  LetE :: (PC.QTyName, Product, ValueE) -> ([ValueE] -> ValueE) -> ValueE
+
+letE :: (PC.QTyName, Product, ValueE) -> ([ValueE] -> ValueE) -> ValueE
+letE = LetE
+
+fieldE :: (PC.QTyName, PC.InfoLess PC.FieldName) -> ValueE -> ValueE
+fieldE = FieldE
+
+lamE :: (ValueE -> ValueE) -> ValueE
+lamE = LamE
+
+(@) :: ValueE -> ValueE -> ValueE
+(@) = AppE
+
+caseE :: (PC.QTyName, Sum) -> ValueE -> ((Ctor, [ValueE]) -> ValueE) -> ValueE
+caseE = CaseE
+
+refE :: Ref -> ValueE
+refE = RefE
+
+{- | Wrapper types.
+ TODO(bladyjoker): Refactor `ProtoCompat.Eval` to have these types explicitly named.
+-}
+type Sum = OMap (PC.InfoLess PC.ConstrName) E.Ty
+
+type Product = [E.Ty]
+type Record = OMap (PC.InfoLess PC.FieldName) E.Ty
+
+type Ctor = (PC.InfoLess PC.ConstrName, Product)
+type Field = (PC.InfoLess PC.FieldName, E.Ty)
+
+type SumImpl = PC.QTyName -> Sum -> ValueE
+type ProductImpl = PC.QTyName -> Product -> ValueE
+type RecordImpl = PC.QTyName -> Record -> ValueE

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal.hs
@@ -38,6 +38,9 @@ data ValueE where
   CaseE :: (PC.QTyName, Sum) -> ValueE -> ((Ctor, [ValueE]) -> ValueE) -> ValueE
   FieldE :: (PC.QTyName, PC.InfoLess PC.FieldName) -> ValueE -> ValueE
   LetE :: (PC.QTyName, Product, ValueE) -> ([ValueE] -> ValueE) -> ValueE
+  IntE :: Int -> ValueE
+  ListE :: [ValueE] -> ValueE
+  ErrorE :: String -> ValueE
 
 letE :: (PC.QTyName, Product, ValueE) -> ([ValueE] -> ValueE) -> ValueE
 letE = LetE

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal/Derive.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal/Derive.hs
@@ -1,0 +1,34 @@
+module LambdaBuffers.Codegen.LamVal.Derive (deriveImpl) where
+
+import LambdaBuffers.Codegen.LamVal (ProductImpl, RecordImpl, SumImpl, ValueE)
+import LambdaBuffers.Compiler.ProtoCompat.Eval qualified as E
+import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+
+deriveImpl' ::
+  PC.ModuleName ->
+  PC.TyDefs ->
+  SumImpl ->
+  ProductImpl ->
+  RecordImpl ->
+  PC.QTyName ->
+  PC.Ty ->
+  Either String ValueE
+deriveImpl' mn tydefs sumImpl productImpl recordImpl qtyN ty = case E.runEval mn tydefs ty of
+  Left err -> Left $ "PC.Ty evaluation failed while trying to derive an implementation\n" <> show err
+  Right (E.TySum s _) -> Right $ sumImpl qtyN s
+  Right (E.TyProduct p _) -> Right $ productImpl qtyN p
+  Right (E.TyRecord r _) -> Right $ recordImpl qtyN r
+  Right wrongTy -> Left $ "Type evaluation resulted in an underivable `Ty`\n" <> show wrongTy
+
+deriveImpl ::
+  PC.ModuleName ->
+  PC.TyDefs ->
+  SumImpl ->
+  ProductImpl ->
+  RecordImpl ->
+  PC.Ty ->
+  Either String ValueE
+deriveImpl mn tydefs sumImpl productImpl recordImpl ty@(PC.TyRefI tr) = deriveImpl' mn tydefs sumImpl productImpl recordImpl (PC.qualifyTyRef mn tr) ty
+deriveImpl mn tydefs sumImpl productImpl recordImpl ty@(PC.TyAppI (PC.TyApp (PC.TyRefI tr) _ _)) = deriveImpl' mn tydefs sumImpl productImpl recordImpl (PC.qualifyTyRef mn tr) ty
+deriveImpl _ _ _ _ _ ty = Left $ "I can only derive implementations for `TyRef` and `TyApp`, got\n" <> show ty

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal/Eq.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal/Eq.hs
@@ -1,0 +1,111 @@
+module LambdaBuffers.Codegen.LamVal.Eq (deriveEqImpl) where
+
+import Data.Map.Ordered qualified as OMap
+import LambdaBuffers.Codegen.LamVal (Field, Product, Record, Sum, ValueE, caseE, fieldE, lamE, letE, refE, (@))
+import LambdaBuffers.Codegen.LamVal.Derive (deriveImpl)
+import LambdaBuffers.Compiler.ProtoCompat.Eval qualified as E
+import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+
+-- | `eq` function encoding parametrized by a single `E.Ty` type `eq :: a -> a -> Bool`.
+eqE :: E.Ty -> ValueE
+eqE ty = refE (Just ty, "eq")
+
+falseE :: ValueE
+falseE = refE (Nothing, "false")
+
+trueE :: ValueE
+trueE = refE (Nothing, "true")
+
+andE :: ValueE
+andE = refE (Nothing, "and")
+
+eqSum :: PC.QTyName -> Sum -> ValueE
+eqSum qtyN sumTy =
+  lamE
+    ( \l ->
+        lamE
+          ( \r ->
+              caseE
+                (qtyN, sumTy)
+                l
+                ( \(ctorTyL, lxs) ->
+                    caseE
+                      (qtyN, sumTy)
+                      r
+                      ( \(ctorTyR, rxs) ->
+                          if fst ctorTyL == fst ctorTyR
+                            then
+                              foldl
+                                (\tot (lx, rx, ty) -> andE @ tot @ (eqE ty @ lx @ rx))
+                                trueE
+                                (zip3 lxs rxs (snd ctorTyL))
+                            else falseE
+                      )
+                )
+          )
+    )
+
+{- | Eq on values of a Product type.
+
+module Foo
+
+product Foo a b = a b
+
+Would translate into
+
+data Foo a b = MkFoo a b
+
+(==) = \l -> \r -> let MkFoo x1 x2 = l in let MkFoo x3 x4 = r in x1 == x3 && x2 == x4 && true
+-}
+eqProduct :: PC.QTyName -> Product -> ValueE
+eqProduct qtyN prodTy =
+  lamE
+    ( \l ->
+        lamE
+          ( \r ->
+              letE
+                (qtyN, prodTy, l)
+                ( \lxs ->
+                    letE
+                      (qtyN, prodTy, r)
+                      ( \rxs ->
+                          foldl
+                            (\tot (lx, rx, ty) -> andE @ tot @ (eqE ty @ lx @ rx))
+                            trueE
+                            (zip3 lxs rxs prodTy)
+                      )
+                )
+          )
+    )
+
+{- | Eq on values of a Record type.
+
+module Foo
+
+record Foo a b = {foo : a, bar : b}
+
+Would translate into
+
+data Foo a b = MkFoo {foo'foo :: a, foo'bar :: b}
+
+(==) = \l -> \r -> foo'foo l == foo'foo r && foo'bar l == foo'bar r && true
+-}
+eqRecord :: PC.QTyName -> Record -> ValueE
+eqRecord qtyN recTy =
+  lamE
+    ( \l ->
+        lamE
+          ( \r ->
+              foldl
+                (\tot field -> andE @ tot @ eqField qtyN field l r)
+                trueE
+                (OMap.assocs recTy)
+          )
+    )
+
+eqField :: PC.QTyName -> Field -> ValueE -> ValueE -> ValueE
+eqField qtyN (fieldName, fieldTy) l r = eqE fieldTy @ fieldE (qtyN, fieldName) l @ fieldE (qtyN, fieldName) r
+
+deriveEqImpl :: PC.ModuleName -> PC.TyDefs -> PC.Ty -> Either String ValueE
+deriveEqImpl mn tydefs = deriveImpl mn tydefs eqSum eqProduct eqRecord

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal/PlutusData.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/LamVal/PlutusData.hs
@@ -1,0 +1,89 @@
+module LambdaBuffers.Codegen.LamVal.PlutusData (deriveToPlutusDataImpl) where
+
+import Data.Map.Ordered qualified as OMap
+import LambdaBuffers.Codegen.LamVal (Product, Record, Sum, ValueE (ErrorE, IntE, ListE), caseE, fieldE, lamE, letE, refE, (@))
+import LambdaBuffers.Codegen.LamVal.Derive (deriveImpl)
+import LambdaBuffers.Compiler.ProtoCompat.Eval qualified as E
+import LambdaBuffers.Compiler.ProtoCompat.Indexing qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.InfoLess qualified as PC
+import LambdaBuffers.Compiler.ProtoCompat.Types qualified as PC
+
+toPlutusDataSum :: PC.QTyName -> Sum -> ValueE
+toPlutusDataSum qtyN sumTy =
+  lamE
+    ( \x ->
+        caseE
+          (qtyN, sumTy)
+          x
+          ( \((ctorN, ctorProdTy), xs) ->
+              if isUnitProd ctorProdTy
+                then integerToPlutusDataE @ findCtorName sumTy ctorN
+                else
+                  constrToPlutusDataE
+                    @ findCtorName sumTy ctorN
+                    @ ListE [toPlutusDataE fieldTy @ fieldVal | (fieldVal, fieldTy) <- zip xs ctorProdTy]
+          )
+    )
+
+toPlutusDataProduct :: PC.QTyName -> Product -> ValueE
+toPlutusDataProduct qtyN prodTy =
+  lamE
+    ( \prodVal ->
+        letE
+          (qtyN, prodTy, prodVal)
+          ( \fieldVals ->
+              case (fieldVals, prodTy) of
+                ([], []) -> ErrorE "Got an empty Product type to print in `toPlutusDataProduct`"
+                ([fieldVal], [fieldTy]) -> toPlutusDataE fieldTy @ fieldVal
+                (fieldVals', fieldTys)
+                  | length fieldVals' == length fieldTys ->
+                      listToPlutusDataE
+                        @ ListE
+                          [ toPlutusDataE fieldTy @ fieldVal
+                          | (fieldVal, fieldTy) <- zip fieldVals' fieldTys
+                          ]
+                _ -> ErrorE "Got mismatching number of variables"
+          )
+    )
+
+toPlutusDataRecord :: PC.QTyName -> Record -> ValueE
+toPlutusDataRecord qtyN recTy =
+  lamE
+    ( \recVal ->
+        case OMap.assocs recTy of
+          [] -> ErrorE "Got an empty Record type to print in `toPlutusDataRecord`"
+          [(fieldName, fieldTy)] -> toPlutusDataE fieldTy @ fieldE (qtyN, fieldName) recVal
+          _ ->
+            listToPlutusDataE
+              @ ListE
+                [ toPlutusDataE fieldTy @ fieldE (qtyN, fieldName) recVal
+                | (fieldName, fieldTy) <- OMap.assocs recTy
+                ]
+    )
+
+deriveToPlutusDataImpl :: PC.ModuleName -> PC.TyDefs -> PC.Ty -> Either String ValueE
+deriveToPlutusDataImpl mn tydefs = deriveImpl mn tydefs toPlutusDataSum toPlutusDataProduct toPlutusDataRecord
+
+isUnitProd :: Product -> Bool
+isUnitProd = null
+
+findCtorName :: Sum -> PC.InfoLess PC.ConstrName -> ValueE
+findCtorName sumTy ctorN = case OMap.findIndex ctorN sumTy of
+  Nothing -> ErrorE $ "Failed find an index for constructor named\n" <> PC.withInfoLess ctorN show <> "\nin a sum type\n" <> show sumTy
+  Just ix -> IntE ix
+
+-- | `toPlutusData :: a -> PlutusData`
+toPlutusDataE :: E.Ty -> ValueE
+toPlutusDataE ty = refE (Just ty, "toPlutusData")
+
+-- | `integerData :: IntE -> PlutusData`
+integerToPlutusDataE :: ValueE
+integerToPlutusDataE = refE (Nothing, "integerData")
+
+-- | `constrData :: IntE -> ListE PlutusData -> PlutusData`
+constrToPlutusDataE :: ValueE
+constrToPlutusDataE = refE (Nothing, "constrData")
+
+-- | `listData :: ListE PlutusData -> PlutusData`
+listToPlutusDataE :: ValueE
+listToPlutusDataE = refE (Nothing, "listData")

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Print.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Print.hs
@@ -2,10 +2,13 @@ module LambdaBuffers.Codegen.Print (
   runPrint,
   Context (..),
   MonadPrint,
-  ctxLbTyImports,
+  ctxTyImports,
   ctxOpaqueTyImports,
   ctxTyExports,
+  ctxClassImports,
+  ctxRuleImports,
   ctxConfig,
+  ctxCompilerInput,
   ctxModule,
 ) where
 
@@ -32,9 +35,12 @@ type PrintM o c = ReaderT (Context o c) (Except Error)
 type Error = (PC.SourceInfo, Text)
 
 data Context o c = MkContext
-  { _ctxModule :: PC.Module
-  , _ctxLbTyImports :: Set PC.QTyName
+  { _ctxCompilerInput :: PC.CompilerInput -- TODO(bladyjoker): Use proper `CodegenInput`.
+  , _ctxModule :: PC.Module -- TODO(bladyjoker): Turn into a `ModuleName` and do a lookup on the CI.
+  , _ctxTyImports :: Set PC.QTyName
   , _ctxOpaqueTyImports :: Set o
+  , _ctxClassImports :: Set c
+  , _ctxRuleImports :: Set (PC.InfoLess PC.ModuleName)
   , _ctxTyExports :: Set (PC.InfoLess PC.TyName)
   , _ctxConfig :: Config o c
   }

--- a/lambda-buffers-codegen/test/Test/LambdaBuffers/Codegen/Haskell.hs
+++ b/lambda-buffers-codegen/test/Test/LambdaBuffers/Codegen/Haskell.hs
@@ -36,7 +36,7 @@ prints goldensFp = testCase goldensFp $ do
     Right res -> return res
   for_
     (ci' ^. #modules)
-    ( \m -> case H.runPrint cfg m of
+    ( \m -> case H.runPrint cfg ci' m of
         Left err -> assertFailure (show err)
         Right (fp', printed) -> do
           fp <- Paths.getDataFileName ("data/goldens/autogen" </> fp')

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/MiniLog.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/MiniLog.hs
@@ -43,8 +43,8 @@ data Term f a
  ```
  Here we see 2 clauses, the first one has for the `clauseHead` a `Term`
  'animal(X)' and for the body a single `Term` 'human(X)'. Notice that they share
- a `Var` 'X'. The second clause with has the `clauseHead` a `Term`
- 'human(socrates)' and it is also called a 'fact', which simply means it's
+ a `Var` 'X'. The second clause has the `clauseHead` a `Term`
+ 'human(socrates)' and it's also called a 'fact', which simply means it's
  'true' as it has no `clauseBody` as a condition. 'socrates' is an `Atom` (a
  ground value).
 -}

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Eval.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/Eval.hs
@@ -13,7 +13,7 @@ import Data.Map.Ordered qualified as OMap
 import Data.ProtoLens (Message (defMessage))
 import LambdaBuffers.Compiler.ProtoCompat qualified as PC
 import LambdaBuffers.Compiler.ProtoCompat.Utils (prettyModuleName)
-import Prettyprinter (Doc, LayoutOptions (LayoutOptions), PageWidth (Unbounded), Pretty (pretty), concatWith, dot, enclose, encloseSep, hsep, layoutPretty, lparen, pipe, rparen, space, (<+>))
+import Prettyprinter (Doc, LayoutOptions (LayoutOptions), PageWidth (Unbounded), Pretty (pretty), colon, comma, concatWith, dot, enclose, encloseSep, hsep, layoutPretty, lbrace, lparen, pipe, rbrace, rparen, space, (<+>))
 import Prettyprinter.Render.String (renderShowS)
 import Proto.Compiler qualified as P
 import Proto.Compiler_Fields qualified as P
@@ -33,7 +33,7 @@ prettyTy :: Ty -> Doc a
 prettyTy (TyVar tv) = pretty $ tv ^. #varName . #name
 prettyTy (TyAbs args body _) =
   if null args
-    then prettyTy body
+    then enclose lparen rparen $ "\\" <> prettyTy body
     else enclose lparen rparen $ printArgs args <+> "->" <+> prettyTy body
   where
     printArgs :: OMap (PC.InfoLess PC.VarName) PC.TyArg -> Doc a
@@ -44,10 +44,13 @@ prettyTy (TySum ctors _s) = enclose lparen rparen $ sepWith (space <> pipe <> sp
     prettyCtor :: (PC.InfoLess PC.ConstrName, Ty) -> Doc a
     prettyCtor (cn, p) = pretty (PC.withInfoLess cn (view #name)) <+> prettyTy p
 prettyTy (TyProduct fields _t) = hsep $ prettyTy <$> fields
-prettyTy (TyRecord fields _r) = hsep $ prettyTy <$> toList fields
+prettyTy (TyRecord fields _r) = encloseSep lbrace rbrace comma $ prettyField <$> OMap.assocs fields
 prettyTy (TyOpaque _) = "opq"
 prettyTy (TyRef (PC.LocalI lr)) = pretty $ lr ^. #tyName . #name
 prettyTy (TyRef (PC.ForeignI fr)) = prettyModuleName (fr ^. #moduleName) <> dot <> pretty (fr ^. #tyName . #name)
+
+prettyField :: (PC.InfoLess PC.FieldName, Ty) -> Doc ann
+prettyField (fn, ty) = PC.withInfoLess fn (pretty . view #name) <+> colon <+> prettyTy ty
 
 sepWith :: Foldable t => Doc ann -> t (Doc ann) -> Doc ann
 sepWith d = concatWith (\l r -> l <> d <> r)
@@ -105,8 +108,9 @@ runEval' mn tds ty =
    in runExcept p
 
 eval :: MonadEval m => Ty -> m Ty
-eval (TyRef tr) = resolveTyRef tr >>= eval
+eval (TyRef tr) = eval (TyApp (TyRef tr) [] Nothing)
 eval (TyApp (TyRef tr) args t) = resolveTyRef tr >>= (\f -> eval $ TyApp f args t)
+eval (TyApp (TyAbs args body _) [] _) | args == OMap.empty = return body
 eval (TyApp (TyAbs args' body _) tys _) =
   let actx' = Map.fromList $ zip (PC.mkInfoLess . view #argName <$> toList args') tys
    in local (\ctx -> ctx & ctxTyArgs %~ Map.union actx') (subst body)

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/FromProto.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/ProtoCompat/FromProto.hs
@@ -615,6 +615,7 @@ instance IsMessage P.Module PC.Module where
       (cldefs, mulClDefs) <- parseAndIndex (\cldef -> mkInfoLess $ cldef ^. #className) (m ^. P.classDefs)
       (impts, mulImpts) <- parseAndIndex mkInfoLess (m ^. P.imports)
       insts <- traverse fromProto $ m ^. P.instances
+      derives <- traverse fromProto $ m ^. P.derives
       si <- fromProto $ m ^. P.sourceInfo
       let mulTyDefsErrs =
             [ FPProtoParseError $
@@ -639,7 +640,7 @@ instance IsMessage P.Module PC.Module where
             ]
           protoParseErrs = mulTyDefsErrs ++ mulClassDefsErrs ++ mulImptsErrs
       if null protoParseErrs
-        then pure $ PC.Module mnm tydefs cldefs insts [] impts si
+        then pure $ PC.Module mnm tydefs cldefs insts derives impts si
         else throwError protoParseErrs
 
   toProto (PC.Module mnm tdefs cdefs insts drv impts si) =

--- a/lambda-buffers-compiler/test/Test/LambdaBuffers/Compiler/ProtoCompat/Eval.hs
+++ b/lambda-buffers-compiler/test/Test/LambdaBuffers/Compiler/ProtoCompat/Eval.hs
@@ -86,6 +86,26 @@ test =
           (Just 2)
           (U.lr "List" U.@ [U.lr "Foo" U.@ [U.tv "a"]])
           "(Nil  | Cons (MkFoo (Prelude.Either Prelude.Int8 a)) (Nil  | Cons (Foo a) (List (Foo a))))"
+      , fooCiTestCase
+          "Bar 1-> Prelude.Int8"
+          (Just 1)
+          (U.lr "Bar")
+          "Prelude.Int8"
+      , fooCiTestCase
+          "Baz 1-> Prelude.Int8"
+          (Just 1)
+          (U.lr "Baz")
+          "{baz : Prelude.Int8}"
+      , fooCiTestCase
+          "Beez Text 1-> {baz : Prelude.Int8,beez : Prelude.Text}"
+          (Just 1)
+          (U.lr "Beez" U.@ [U.fr ["Prelude"] "Text"])
+          "{baz : Prelude.Int8,beez : Prelude.Text}"
+      , fooCiTestCase
+          "Beer Text 1-> Prelude.Int8 Prelude.Text"
+          (Just 1)
+          (U.lr "Beer" U.@ [U.fr ["Prelude"] "Text"])
+          "Prelude.Int8 Prelude.Text"
       ]
 
 fooCi :: PC.CompilerInput
@@ -95,6 +115,17 @@ fooCi =
     , U.mod
         ["Foo"]
         [ U.td "Foo" (U.abs ["a"] $ U.sum [("MkFoo", [U.fr ["Prelude"] "Either" U.@ [U.fr ["Prelude"] "Int8", U.tv "a"]])])
+        , U.td "Baz" (U.abs [] $ U.recrd [("baz", U.fr ["Prelude"] "Int8")])
+        , U.td "Bar" (U.abs [] $ U.prod' [U.fr ["Prelude"] "Int8"])
+        , U.td
+            "Beez"
+            ( U.abs ["a"] $
+                U.recrd
+                  [ ("baz", U.fr ["Prelude"] "Int8")
+                  , ("beez", U.tv "a")
+                  ]
+            )
+        , U.td "Beer" (U.abs ["a"] $ U.prod' [U.fr ["Prelude"] "Int8", U.tv "a"])
         , U.td'maybe
         , U.td'either
         , U.td'list

--- a/lambda-buffers-compiler/test/Test/LambdaBuffers/Compiler/ProtoCompat/Utils.hs
+++ b/lambda-buffers-compiler/test/Test/LambdaBuffers/Compiler/ProtoCompat/Utils.hs
@@ -24,6 +24,8 @@ module Test.LambdaBuffers.Compiler.ProtoCompat.Utils (
   mod'prelude,
   fcr,
   inst',
+  recrd,
+  prod',
 ) where
 
 import Control.Lens ((^.))
@@ -65,8 +67,17 @@ ctor (cn', tys) = (PC.mkInfoLess $ cn cn', PC.Constructor (cn cn') (prod tys))
 prod :: [PC.Ty] -> PC.Product
 prod tys = PC.Product tys def
 
+prod' :: [PC.Ty] -> PC.TyBody
+prod' = PC.ProductI . prod
+
+recrd :: [(Text, PC.Ty)] -> PC.TyBody
+recrd fields = PC.RecordI $ PC.Record (OMap.fromList [(PC.mkInfoLess . fn $ n, PC.Field (fn n) t) | (n, t) <- fields]) def
+
 cn :: Text -> PC.ConstrName
 cn n = PC.ConstrName n def
+
+fn :: Text -> PC.FieldName
+fn n = PC.FieldName n def
 
 vn :: Text -> PC.VarName
 vn n = PC.VarName n def

--- a/lambda-buffers-proto/compiler.proto
+++ b/lambda-buffers-proto/compiler.proto
@@ -547,7 +547,8 @@ message Module {
   // Type class derive statements.
   repeated Derive derives = 5;
   // Imported modules the Compiler consults when searching for
-  // instance clauses.
+  // type class rules.
+  // TODO(bladyjoker): Rename to ruleImports.
   // Duplicate imports MUST be reported with
   // `ProtoParseError.MultipleImportError`.
   repeated ModuleName imports = 6;


### PR DESCRIPTION
DONE
- `LamVal` an intermediate representation of a minimal functional language that works with LB types and various implementations can be specified in (eq, toPlutusData, fromPlutusData, toJson, fromJson etc.)
- Haskell backend for `LamVal`
- Haskell instance definition printing for the `Eq` type class
- Haskell instance definition printing for the `PlutusTx.ToData` type class