### PR TITLE
Add x86_64-darwin to supported system in our flakes (tested)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         (import ./docs/build.nix)
       ];
       debug = true;
-      systems = [ "x86_64-linux" ];
+      systems = [ "x86_64-linux" "x86_64-darwin" ];
       perSystem = { system, config, ... }:
         let
           inherit self;


### PR DESCRIPTION
Adding `x86_64-darwin` to supported systems in `flake.nix` after building everything successfully on a Mac.

Unfortunately I don't think there's a way we could verify this on our CI.
