### PR TITLE
Added `lbf-prelude-to-purescript` and `lbf-plutus-to-purescript` scripts to the frontend

### DIFF
--- a/lambda-buffers-frontend/build.nix
+++ b/lambda-buffers-frontend/build.nix
@@ -67,6 +67,8 @@
             config.packages.lbf-pure
             config.packages.lbf-prelude-to-haskell
             config.packages.lbf-plutus-to-haskell
+            config.packages.lbf-prelude-to-purescript
+            config.packages.lbf-plutus-to-purescript
           ];
         };
       };
@@ -123,6 +125,40 @@
             work-dir = ".work";
           }} $@;
         '';
+
+        lbf-prelude-to-purescript = pkgs.writeShellScriptBin "lbf-prelude-to-purescript" ''
+          export LB_COMPILER=${config.packages.lbc}/bin/lbc;
+          mkdir autogen;
+          mkdir .work;
+          ${config.overlayAttrs.lbf-nix.lbfBuild.buildCall {
+            files = [];
+            import-paths = [ config.packages.lbf-prelude ];
+            gen = "${config.packages.lbg-purescript}/bin/lbg-purescript";
+            gen-classes = ["Prelude.Eq" "Prelude.Json"];
+            gen-dir = "autogen";
+            gen-opts = ["--config=${config.packages.codegen-configs}/purescript-prelude-base.json"];
+            work-dir = ".work";
+          }} $@;
+        '';
+
+        lbf-plutus-to-purescript = pkgs.writeShellScriptBin "lbf-plutus-to-purescript" ''
+          export LB_COMPILER=${config.packages.lbc}/bin/lbc;
+          mkdir autogen;
+          mkdir .work;
+          ${config.overlayAttrs.lbf-nix.lbfBuild.buildCall {
+            files = [];
+            import-paths = [ config.packages.lbf-prelude config.packages.lbf-plutus ];
+            gen = "${config.packages.lbg-purescript}/bin/lbg-purescript";
+            gen-classes = [ "Prelude.Eq" "Prelude.Json" "Plutus.V1.PlutusData" ];
+            gen-dir = "autogen";
+            gen-opts = [
+                "--config=${config.packages.codegen-configs}/purescript-prelude-base.json"
+                "--config=${config.packages.codegen-configs}/purescript-plutus-ctl.json"
+            ];
+            work-dir = ".work";
+          }} $@;
+        '';
+
       };
 
       inherit (hsNixFlake) checks;


### PR DESCRIPTION
This PR does the following:
- Adds short scripts for `lbf-prelude-to-purescript` and `lbf-plutus-to-purescript`


TODOs for future issues:
- Change all occurrences of just `$@` to `"$@"` so whitespace in arguments in handled properly. Note that `shellcheck` suggests this.
- Maybe some sort of reasonable "end to end" testing of these scripts i.e., testing the output of the shell scripts compile, has expected instances, etc.
- Add `-p` to `mkdir` calls so the shell scripts don't error the second time we run them.

The rest of the sections demonstrate `script` outputs which show that the implemented shell scripts work. Commands start with `$ ` and are followed by the output.

# `lbf-prelude-to-purescript`
```bash
$ nix develop --ignore-environment .#lb
xset:  unable to open display ""
$ cat TEST.lbf
module TEST

import Prelude

record Dog = { age : Integer, breed : Bytes}

derive Eq Dog
$ lbf-prelude-to-purescript TEST.lbf
mkdir: cannot create directory ‘autogen’: File exists
mkdir: cannot create directory ‘.work’: File exists
[lbf][INFO] Success from: /nix/store/hn87z4b5qaw1888zys761nyxwm2gyxal-lambda-buffers-compiler-exe-lbc-0.1.0.0/bin/lbc compile --input-file .work/compiler-input.pb --output-file .work/compiler-output.pb
[lbf][INFO] Compilation OK
[lbf][INFO] Success from: /nix/store/zy7ndkisilz98r95shxycj1hzc59j2hl-lbg-purescript/bin/lbg-purescript --input .work/codegen-input.pb --output .work/codegen-output.pb --gen-dir autogen --gen-class Prelude.Eq --gen-class Prelude.Json '--config=/nix/store/7h1hnhy5al8v272c4l1vrsxc2h3i9si4-codegen-configs/purescript-prelude-base.json' TEST
[lbf][INFO] Codegen OK
$ cat autogen/build.json
["newtype","prelude"]
$ cat autogen/LambdaBuffers/TEST.purs
module LambdaBuffers.TEST (Dog(..)) where

import LambdaBuffers.Prelude as LambdaBuffers.Prelude
import Data.Generic.Rep as Data.Generic.Rep
import Data.Newtype as Data.Newtype
import Data.Show as Data.Show
import Data.Show.Generic as Data.Show.Generic
import Prelude as Prelude


newtype Dog = Dog { age :: LambdaBuffers.Prelude.Integer
                  , breed :: LambdaBuffers.Prelude.Bytes}
derive instance Data.Newtype.Newtype Dog _
derive instance Data.Generic.Rep.Generic Dog _
instance Data.Show.Show Dog where
  show = Data.Show.Generic.genericShow


instance Prelude.Eq Dog where
  eq = (\x0 -> (\x1 -> Prelude.(&&) (Prelude.(&&) (true) (Prelude.(==) ((Data.Newtype.unwrap x0).age) ((Data.Newtype.unwrap x1).age))) (Prelude.(==) ((Data.Newtype.unwrap x0).breed) ((Data.Newtype.unwrap x1).breed)) ) )
```

# `lbf-plutus-to-purescript`

```bash
$ nix develop --ignore-environment .#lb
trace: WARNING: 9.2.5 is out of date, consider using 9.2.7.
xset:  unable to open display ""
$ cat TEST.lbf
module TEST

import Prelude (Eq)
import Plutus.V1
import Plutus.V2

sum Dog = Dog Address TxOut

derive Eq Dog
derive PlutusData Dog
$ lbf-plutus-to-purescript TEST.lbf
mkdir: cannot create directory ‘autogen’: File exists
mkdir: cannot create directory ‘.work’: File exists
[lbf][INFO] Success from: /nix/store/hn87z4b5qaw1888zys761nyxwm2gyxal-lambda-buffers-compiler-exe-lbc-0.1.0.0/bin/lbc compile --input-file .work/compiler-input.pb --output-file .work/compiler-output.pb
[lbf][INFO] Compilation OK
[lbf][INFO] Success from: /nix/store/zy7ndkisilz98r95shxycj1hzc59j2hl-lbg-purescript/bin/lbg-purescript --input .work/codegen-input.pb --output .work/codegen-output.pb --gen-dir autogen --gen-class Prelude.Eq --gen-class Prelude.Json --gen-class Plutus.V1.PlutusData '--config=/nix/store/7h1hnhy5al8v272c4l1vrsxc2h3i9si4-codegen-configs/purescript-prelude-base.json' '--config=/nix/store/7h1hnhy5al8v272c4l1vrsxc2h3i9si4-codegen-configs/purescript-plutus-ctl.json' TEST
[lbf][INFO] Codegen OK
$ cat autogen/
LambdaBuffers/ build.json
$ cat autogen/build.json
["bigint","cardano-transaction-lib","lbr-plutus","lbr-prelude","maybe","prelude","tuple"]
$ cat autogen/LambdaBuffers/TEST.purs
module LambdaBuffers.TEST (Dog(..)) where

import LambdaBuffers.Plutus.V1 as LambdaBuffers.Plutus.V1
import LambdaBuffers.Plutus.V2 as LambdaBuffers.Plutus.V2
import LambdaBuffers.Prelude as LambdaBuffers.Prelude
import Ctl.Internal.FromData as Ctl.Internal.FromData
import Ctl.Internal.ToData as Ctl.Internal.ToData
import Data.BigInt as Data.BigInt
import Data.Generic.Rep as Data.Generic.Rep
import Data.Maybe as Data.Maybe
import Data.Show as Data.Show
import Data.Show.Generic as Data.Show.Generic
import Data.Tuple as Data.Tuple
import LambdaBuffers.Runtime.Plutus as LambdaBuffers.Runtime.Plutus
import LambdaBuffers.Runtime.Prelude as LambdaBuffers.Runtime.Prelude
import Prelude as Prelude


data Dog = Dog'Dog LambdaBuffers.Plutus.V1.Address LambdaBuffers.Plutus.V2.TxOut
derive instance Data.Generic.Rep.Generic Dog _
instance Data.Show.Show Dog where
  show = Data.Show.Generic.genericShow


instance Prelude.Eq Dog where
  eq = (\x0 -> (\x1 -> case x0 of
                       Dog'Dog x2 x3 -> case x1 of
                                        Dog'Dog x4 x5 -> Prelude.(&&) (Prelude.(&&) (true) (Prelude.(==) (x2) (x4))) (Prelude.(==) (x3) (x5)) ) )

instance Ctl.Internal.ToData.ToData Dog where
  toData = (\x0 -> case x0 of
                   Dog'Dog x1 x2 -> LambdaBuffers.Runtime.Plutus.pdConstr ((Data.BigInt.fromInt 0)) ([Ctl.Internal.ToData.toData (x1)
                                                                                                      , Ctl.Internal.ToData.toData (x2)]) )

instance Ctl.Internal.FromData.FromData Dog where
  fromData = (\x0 -> LambdaBuffers.Runtime.Plutus.casePlutusData ((\x1 -> (\x2 -> LambdaBuffers.Runtime.Prelude.caseInt [Data.Tuple.Tuple (Data.BigInt.fromInt 0) (case x2 of
                                                                                                                                                                     [x3
                                                                                                                                                                      , x4] -> Prelude.(>>=) (Ctl.Internal.FromData.fromData (x3)) ((\x5 -> Prelude.(>>=) (Ctl.Internal.FromData.fromData (x4)) ((\x6 -> Data.Maybe.Just (Dog'Dog x5 x6) )) ))
                                                                                                                                                                     x7 -> Data.Maybe.Nothing)] (\x8 -> Data.Maybe.Nothing ) x1 ) )) ((\x9 -> Data.Maybe.Nothing )) ((\x10 -> LambdaBuffers.Runtime.Prelude.caseInt [] (\x11 -> Data.Maybe.Nothing ) x10 )) ((\x12 -> Data.Maybe.Nothing )) (x0) )
```