### PR TITLE
Adding `devShells` to play with generated schema code for Haskell's Prelude and Plutus Prelude

### DIFF
--- a/libs/build.nix
+++ b/libs/build.nix
@@ -72,8 +72,8 @@
         # `packages.lbf-prelude-haskell`) essentially generates a cabal
         # project from the `./Prelude.lbf` schema; and the following uses
         # `haskell.nix` to convert the `.cabal` project into a dev shell.
-        # This is a dev shell which provides ghc with
-        #   - `lbf-prelude-haskell` package (and its dependencies)
+        # This is a dev shell which provides
+        #   - ghc with `lbf-prelude-haskell` package (and its dependencies)
         #   - the CLI application (`lbf-prelude-to-haskell`) to compile `.lbf`
         #   schemas
         let
@@ -96,7 +96,7 @@
                   allComponent.doHaddock = true;
 
                   # Enable strict compilation
-                  lbt-plutus-haskell.configureFlags = [ "-f-dev" ];
+                  lbf-prelude.configureFlags = [ "-f-dev" ];
                 };
               })
             ];
@@ -139,8 +139,8 @@
         # essentially generates a cabal project from the `*.lbf` schemas; and
         # the following uses `haskell.nix` to convert the `.cabal` project into
         # a dev shell.
-        # This is a dev shell which provides ghc with
-        #   - `lbf-plutus-haskell` package (and its dependencies)
+        # This is a dev shell which provides
+        #   - ghc with `lbf-plutus-haskell` package (and its dependencies)
         #   - the CLI application (`lbf-plutus-to-haskell`) to compile `.lbf`
         #   schemas.
         #
@@ -168,7 +168,7 @@
                   allComponent.doHaddock = true;
 
                   # Enable strict compilation
-                  lbt-plutus-haskell.configureFlags = [ "-f-dev" ];
+                  lbf-plutus.configureFlags = [ "-f-dev" ];
                 };
               })
             ];


### PR DESCRIPTION
This PR does the following:
- Added the following attributes in `libs/build.nix` 
    - `dev-prelude-haskell`: a devShell for when someone wants to play with `libs/lbf-prelude/Prelude.lbf` in Haskell
    - `dev-plutustx`: a devShell for when someone wants to play with `libs/lbf-plutus/Plutus/V1.lbf` or `libs/lbf-plutus/Plutus/V2.lbf` in Haskell

The rest of the sections demonstrate how to use.

# `dev-prelude-haskell`
The following demonstrates `script` output (with some details omitted) of playing around with `TEST.lbf` with the developer shell for `dev-prelude-haskell`. Commands are prefixed with `$` and output follows.

Note the `--ignore-environment` flag is just used for demonstration purposes to show that the devShell environment really is complete with the required information.

```bash
$ nix develop --ignore-environment .#dev-prelude-haskell
xset:  unable to open display ""
WARNING: pre-commit-hooks.nix: git command not found; skipping installation.
$ cat TEST.lbf
module TEST

import Prelude

sum Dog = Dog Integer

derive Eq Dog

$ lbf-prelude-to-haskell TEST.lbf
mkdir: cannot create directory ‘.work’: File exists
[lbf][INFO] Success from: /nix/store/hn87z4b5qaw1888zys761nyxwm2gyxal-lambda-buffers-compiler-exe-lbc-0.1.0.0/bin/lbc compile --input-file .work/compiler-input.pb --output-file .work/compiler-output.pb
[lbf][INFO] Compilation OK
[lbf][INFO] Success from: /nix/store/9s58v4ad8bk4qq0ml0cirpcgfr1nfaj8-lbg-haskell/bin/lbg-haskell --input .work/codegen-input.pb --output .work/codegen-output.pb --gen-dir autogen --gen-class Prelude.Eq --gen-class Prelude.Json '--config=/nix/store/7h1hnhy5al8v272c4l1vrsxc2h3i9si4-codegen-configs/haskell-prelude-base.json' TEST
[lbf][INFO] Codegen OK
$ cat autogen/LambdaBuffers/TEST.hs
module LambdaBuffers.TEST (Dog(..)) where

import qualified LambdaBuffers.Prelude
import qualified Prelude


data Dog = Dog'Dog LambdaBuffers.Prelude.Integer deriving Prelude.Show


instance Prelude.Eq Dog where
  (==) = (\x0 -> (\x1 -> case x0 of
                           Dog'Dog x2 -> case x1 of
                                           Dog'Dog x3 -> (Prelude.&&) (Prelude.True) ((Prelude.==) (x2) (x3)) ) )
$ ghci autogen/LambdaBuffers/TEST.hs
GHCi, version 9.2.5: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/jared/Documents/Work/lambda-buffers/.ghci
[1 of 1] Compiling LambdaBuffers.TEST ( autogen/LambdaBuffers/TEST.hs, interpreted )
Ok, one module loaded.
 :i Dog
type Dog :: *
data Dog = Dog'Dog LambdaBuffers.Prelude.Integer
  	-- Defined at autogen/LambdaBuffers/TEST.hs:7:1
instance Prelude.Eq Dog
  -- Defined at autogen/LambdaBuffers/TEST.hs:10:10
instance Prelude.Show Dog
  -- Defined at autogen/LambdaBuffers/TEST.hs:7:59
 Dog'Dog 0
Dog'Dog 0

Leaving GHCi.
```

# `dev-plutustx`
Similarly to the previous section, the following demonstrates `script` output (with some details omitted) of playing around with `TEST.lbf` with the developer shell for `dev-plutustx`. Commands are prefixed with `$` and output follows.

Note the `--ignore-environment` flag is just used for demonstration purposes to show that the devShell environment really is complete with the required information.

```bash
$ nix develop --ignore-environment .#dev-plutustx
trace: WARNING: 9.2.5 is out of date, consider using 9.2.7.
xset:  unable to open display ""
WARNING: pre-commit-hooks.nix: git command not found; skipping installation.
$ cat TEST.lbf
module TEST

import Prelude (Eq)
import Plutus.V1
import Plutus.V2

sum Dog = Dog Address TxOut

derive Eq Dog
derive PlutusData Dog
$ lbf-plutus-to-haskell TEST.lbf
mkdir: cannot create directory ‘autogen’: File exists
mkdir: cannot create directory ‘.work’: File exists
[lbf][INFO] Success from: /nix/store/hn87z4b5qaw1888zys761nyxwm2gyxal-lambda-buffers-compiler-exe-lbc-0.1.0.0/bin/lbc compile --input-file .work/compiler-input.pb --output-file .work/compiler-output.pb
[lbf][INFO] Compilation OK
[lbf][INFO] Success from: /nix/store/9s58v4ad8bk4qq0ml0cirpcgfr1nfaj8-lbg-haskell/bin/lbg-haskell --input .work/codegen-input.pb --output .work/codegen-output.pb --gen-dir autogen --gen-class Prelude.Eq --gen-class Prelude.Json --gen-class Plutus.V1.PlutusData '--config=/nix/store/7h1hnhy5al8v272c4l1vrsxc2h3i9si4-codegen-configs/haskell-prelude-base.json' '--config=/nix/store/7h1hnhy5al8v272c4l1vrsxc2h3i9si4-codegen-configs/haskell-plutus-plutustx.json' TEST
[lbf][INFO] Codegen OK
$ cat autogen/LambdaBuffers/TEST.hs
module LambdaBuffers.TEST (Dog(..)) where

import qualified LambdaBuffers.Plutus.V1
import qualified LambdaBuffers.Plutus.V2
import qualified LambdaBuffers.Prelude
import qualified LambdaBuffers.Runtime.Plutus
import qualified PlutusTx
import qualified PlutusTx.Builtins
import qualified PlutusTx.Eq
import qualified Prelude


data Dog = Dog'Dog LambdaBuffers.Plutus.V1.Address
                   LambdaBuffers.Plutus.V2.TxOut deriving Prelude.Show


instance Prelude.Eq Dog where
  (==) = (\x0 -> (\x1 -> case x0 of
                           Dog'Dog x2 x3 -> case x1 of
                                              Dog'Dog x4 x5 -> (Prelude.&&) ((Prelude.&&) (Prelude.True) ((Prelude.==) (x2) (x4))) ((Prelude.==) (x3) (x5)) ) )

instance PlutusTx.Eq.Eq Dog where
  (==) = (\x0 -> (\x1 -> case x0 of
                           Dog'Dog x2 x3 -> case x1 of
                                              Dog'Dog x4 x5 -> (Prelude.&&) ((Prelude.&&) (Prelude.True) ((PlutusTx.Eq.==) (x2) (x4))) ((PlutusTx.Eq.==) (x3) (x5)) ) )

instance PlutusTx.ToData Dog where
  toBuiltinData = (\x0 -> case x0 of
                            Dog'Dog x1 x2 -> PlutusTx.Builtins.mkConstr (0) ([PlutusTx.toBuiltinData (x1)
                                                                              , PlutusTx.toBuiltinData (x2)]) )

instance PlutusTx.FromData Dog where
  fromBuiltinData = (\x0 -> LambdaBuffers.Runtime.Plutus.casePlutusData ((\x1 -> (\x2 -> case x1 of
                                                                                           0 -> case x2 of
                                                                                                  [x3
                                                                                                   , x4] -> (Prelude.>>=) (PlutusTx.fromBuiltinData (x3)) ((\x5 -> (Prelude.>>=) (PlutusTx.fromBuiltinData (x4)) ((\x6 -> Prelude.Just (Dog'Dog x5 x6) )) ))
                                                                                                  x7 -> Prelude.Nothing
                                                                                           x8 -> Prelude.Nothing ) )) ((\x9 -> Prelude.Nothing )) ((\x10 -> case x10 of
                                                                                                                                                              x11 -> Prelude.Nothing )) ((\x12 -> Prelude.Nothing )) (x0) )
$ ghci autogen/LambdaBuffers/TEST.hs
GHCi, version 9.2.5: https://www.haskell.org/ghc/  :? for help
Loaded GHCi configuration from /home/jared/Documents/Work/lambda-buffers/.ghci
[1 of 1] Compiling LambdaBuffers.TEST ( autogen/LambdaBuffers/TEST.hs, interpreted )
Ok, one module loaded.
 :i Dog
type Dog :: *
data Dog
  = Dog'Dog LambdaBuffers.Plutus.V1.Address
            LambdaBuffers.Plutus.V2.TxOut
  	-- Defined at autogen/LambdaBuffers/TEST.hs:13:1
instance PlutusTx.Eq.Eq Dog
  -- Defined at autogen/LambdaBuffers/TEST.hs:22:10
instance Prelude.Eq Dog
  -- Defined at autogen/LambdaBuffers/TEST.hs:17:10
instance PlutusTx.FromData Dog
  -- Defined at autogen/LambdaBuffers/TEST.hs:32:10
instance Prelude.Show Dog
  -- Defined at autogen/LambdaBuffers/TEST.hs:14:59
instance PlutusTx.ToData Dog
  -- Defined at autogen/LambdaBuffers/TEST.hs:27:10
 :t Dog'Dog
Dog'Dog
  :: LambdaBuffers.Plutus.V1.Address
     -> LambdaBuffers.Plutus.V2.TxOut -> Dog
 :i LambdaBuffers.Plutus.V1.Address
type LambdaBuffers.Plutus.V1.Address :: *
type LambdaBuffers.Plutus.V1.Address =
  PlutusLedgerApi.V1.Address.Address
  	-- Defined in ‘LambdaBuffers.Plutus.V1’
 import PlutusLedgerApi.V1
PlutusLedgerApi.V1                    PlutusLedgerApi.V1.Crypto             PlutusLedgerApi.V1.Scripts
PlutusLedgerApi.V1.Address            PlutusLedgerApi.V1.DCert              PlutusLedgerApi.V1.Time
PlutusLedgerApi.V1.Bytes              PlutusLedgerApi.V1.EvaluationContext  PlutusLedgerApi.V1.Tx
PlutusLedgerApi.V1.Contexts           PlutusLedgerApi.V1.Interval           PlutusLedgerApi.V1.Value
PlutusLedgerApi.V1.Credential         PlutusLedgerApi.V1.ParamName
 import PlutusLedgerApi.V1
 :i Address
type Address :: *
data Address
  = Address {addressCredential :: Credential,
             addressStakingCredential :: Prelude.Maybe StakingCredential}
  	-- Defined in ‘PlutusLedgerApi.V1.Address’
instance Prelude.Eq Address
  -- Defined in ‘PlutusLedgerApi.V1.Address’
instance Prelude.Ord Address
  -- Defined in ‘PlutusLedgerApi.V1.Address’
instance Prelude.Show Address
  -- Defined in ‘PlutusLedgerApi.V1.Address’
instance PlutusTx.Eq.Eq Address
  -- Defined in ‘PlutusLedgerApi.V1.Address’
instance FromData Address
  -- Defined in ‘PlutusLedgerApi.V1.Address’
instance ToData Address -- Defined in ‘PlutusLedgerApi.V1.Address’
instance UnsafeFromData Address
  -- Defined in ‘PlutusLedgerApi.V1.Address’

Leaving GHCi.

```