### PR TITLE
Minor improvements to `lbf` frontend scripts. 

### DIFF
--- a/lambda-buffers-frontend/build.nix
+++ b/lambda-buffers-frontend/build.nix
@@ -90,13 +90,13 @@
         lbf = pkgs.writeShellScriptBin "lbf" ''
           export LB_CODEGEN=${config.packages.lbg-haskell}/bin/lbg-haskell;
           export LB_COMPILER=${config.packages.lbc}/bin/lbc;
-          ${config.packages.lbf-pure}/bin/lbf $@
+          ${config.packages.lbf-pure}/bin/lbf "$@"
         '';
 
         lbf-prelude-to-haskell = pkgs.writeShellScriptBin "lbf-prelude-to-haskell" ''
           export LB_COMPILER=${config.packages.lbc}/bin/lbc;
-          mkdir autogen;
-          mkdir .work;
+          mkdir -p autogen;
+          mkdir -p .work;
           ${config.overlayAttrs.lbf-nix.lbfBuild.buildCall {
             files = [];
             import-paths = [ config.packages.lbf-prelude ];
@@ -105,13 +105,13 @@
             gen-dir = "autogen";
             gen-opts = ["--config=${config.packages.codegen-configs}/haskell-prelude-base.json"];
             work-dir = ".work";
-          }} $@;
+          }} "$@";
         '';
 
         lbf-plutus-to-haskell = pkgs.writeShellScriptBin "lbf-plutus-to-haskell" ''
           export LB_COMPILER=${config.packages.lbc}/bin/lbc;
-          mkdir autogen;
-          mkdir .work;
+          mkdir -p autogen;
+          mkdir -p .work;
           ${config.overlayAttrs.lbf-nix.lbfBuild.buildCall {
             files = [];
             import-paths = [ config.packages.lbf-prelude config.packages.lbf-plutus ];
@@ -123,13 +123,13 @@
               "--config=${config.packages.codegen-configs}/haskell-plutus-plutustx.json"
             ];
             work-dir = ".work";
-          }} $@;
+          }} "$@";
         '';
 
         lbf-prelude-to-purescript = pkgs.writeShellScriptBin "lbf-prelude-to-purescript" ''
           export LB_COMPILER=${config.packages.lbc}/bin/lbc;
-          mkdir autogen;
-          mkdir .work;
+          mkdir -p autogen;
+          mkdir -p .work;
           ${config.overlayAttrs.lbf-nix.lbfBuild.buildCall {
             files = [];
             import-paths = [ config.packages.lbf-prelude ];
@@ -138,13 +138,13 @@
             gen-dir = "autogen";
             gen-opts = ["--config=${config.packages.codegen-configs}/purescript-prelude-base.json"];
             work-dir = ".work";
-          }} $@;
+          }} "$@";
         '';
 
         lbf-plutus-to-purescript = pkgs.writeShellScriptBin "lbf-plutus-to-purescript" ''
           export LB_COMPILER=${config.packages.lbc}/bin/lbc;
-          mkdir autogen;
-          mkdir .work;
+          mkdir -p autogen;
+          mkdir -p .work;
           ${config.overlayAttrs.lbf-nix.lbfBuild.buildCall {
             files = [];
             import-paths = [ config.packages.lbf-prelude config.packages.lbf-plutus ];
@@ -156,7 +156,7 @@
                 "--config=${config.packages.codegen-configs}/purescript-plutus-ctl.json"
             ];
             work-dir = ".work";
-          }} $@;
+          }} "$@";
         '';
 
       };


### PR DESCRIPTION
Following #121 , this PR does some minor improvements to the `lbf` frontend scripts (I'll call these *porcelain* in contrast to the low level *plumbing* -- this is the nomenclature that `git` uses which has a similar architecture! See `man gitcore-tutorial`)

- Replaced `$@` with `"$@"` in the `lbf` scripts. The reason why this is important is because if there's a single argument with a space in it, the former will make it two arguments instead of a single argument.
  
  Moreover, as a minimal example, we can see that `shellcheck` (from CI) doesn't like `$@` either:

  Given: `test.bash` as follows
  ```bash
  #!/bin/bash
  
  echo $@
  ```
  
  We can see that `shellcheck` gets angry
  
  ```
  In test.bash line 3:
  echo $@
       ^-- SC2068 (error): Double quote array expansions to avoid re-splitting elements.
  
  For more information:
    https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  ```

- Added `-p` to `mkdir`
  Previously, if we ran any of the `lbf` shell scripts twice, we'd get something like:
  ```
  $ nix develop .#lb
  trace: WARNING: 9.2.5 is out of date, consider using 9.2.7.
  $ lbf-prelude-to-haskell TEST.lbf
  [lbf][INFO] Success from: /nix/store/hn87z4b5qaw1888zys761nyxwm2gyxal-lambda-buffers-compiler-exe-lbc-0.1.0.0/bin/lbc compile --input-file .work/compiler-input.pb --output-file .work/compiler-output.pb
  [lbf][INFO] Compilation OK
  [lbf][INFO] Success from: /nix/store/9s58v4ad8bk4qq0ml0cirpcgfr1nfaj8-lbg-haskell/bin/lbg-haskell --input .work/codegen-input.pb --output .work/codegen-output.pb --gen-dir autogen --gen-class Prelude.Eq --gen-class Prelude.Json '--config=/nix/store/7h1hnhy5al8v272c4l1vrsxc2h3i9si4-codegen-configs/haskell-prelude-base.json' TEST
  [lbf][INFO] Codegen OK
  $ lbf-prelude-to-haskell TEST.lbf
  mkdir: cannot create directory ‘autogen’: File exists
  mkdir: cannot create directory ‘.work’: File exists
  [lbf][INFO] Success from: /nix/store/hn87z4b5qaw1888zys761nyxwm2gyxal-lambda-buffers-compiler-exe-lbc-0.1.0.0/bin/lbc compile --input-file .work/compiler-input.pb --output-file .work/compiler-output.pb
  [lbf][INFO] Compilation OK
  [lbf][INFO] Success from: /nix/store/9s58v4ad8bk4qq0ml0cirpcgfr1nfaj8-lbg-haskell/bin/lbg-haskell --input .work/codegen-input.pb --output .work/codegen-output.pb --gen-dir autogen --gen-class Prelude.Eq --gen-class Prelude.Json '--config=/nix/store/7h1hnhy5al8v272c4l1vrsxc2h3i9si4-codegen-configs/haskell-prelude-base.json' TEST
  [lbf][INFO] Codegen OK
  ```
  Note the 
  ```
  mkdir: cannot create directory ‘autogen’: File exists
  mkdir: cannot create directory ‘.work’: File exists
  ```
  Not sure if there's a good reason to have this output here, but adding the `-p` flag will silence this.
