### PR TITLE
Remove node2nix from Typescript's Nix utilities

### DIFF
--- a/extras/flake-typescript.nix
+++ b/extras/flake-typescript.nix
@@ -40,26 +40,29 @@ pkgs:
 , ...
 }:
 let
-  # Derivation for the result of calling the CLI tool `node2nix` with the
-  # provided `src`.
-  #
-  # Notes: 
-  #
-  #   - `node2nix` creates a nix expression in `default.nix` of type 
-  #   `{pkgs, system, nodejs} -> {args, sources, tarball, package,  shell, nodeDependencies }` 
-  node2nixExprs =
-    {
-      # Extra flags passed directly to `node2nix`
-      extraFlags ? [ ]
-    }:
-    pkgs.runCommand (name + "-node2nix") { buildInputs = [ pkgs.node2nix nodejs ]; }
+  packageLockDependencies = import ./typescript/fetch-package-lock.nix pkgs { inherit src; };
+
+  # Derivation for
+  # 1. Caching (via npm cache) all dependencies already existing in the package-lock.json
+  # 2. Caching the extra dependencies provided by nix
+  # 3. Installing the extra dependencies provided by  nix to the package-lock.json
+  # 4. npm install all of the above
+  npmProject =
+    pkgs.runCommand (name + "-npm-project") { buildInputs = [ nodejs pkgs.jq ]; }
       ''
         # For some reason, npm likes to call `mkdir $HOME` (which is not
         # writeable when building derivations on nix), so we change `HOME` to a
         # writable directory
-        mkdir -p $TMPDIR/home
         export HOME=$TMPDIR/home
+        echo "Set HOME to $HOME"
 
+        # Create a directory for npm's cache
+        mkdir -p $TMPDIR/cache
+        npm config set cache $TMPDIR/cache
+
+        # Force NPM to remain offline (if it hits the network, it'll fail
+        # anyways because of nix's isolated build environment
+        npm config set offline=true
 
         mkdir -p "$out"
 
@@ -79,23 +82,42 @@ let
         fi
 
         #########################################################
-        # Use `npm` to add the extra tarball dependencies from nix.
+        # Create tarballs of all dependencies already in the lock file
         #########################################################
 
+        # We write the list of `packageLockDependencies` as
+        # `<dependency1>`, `<dependency2>`, ..., `<dependencyN>`
+        # this will create:
+        # ```
+        # echo "Adding <dependency1> to npm's cache"
+        # npm cache add --loglevel-verbose <dependency1>
+        #
+        # echo "Adding <dependency2> to npm's cache"
+        # npm cache add --loglevel-verbose <dependency2>
+        #
+        # ...
+        #
+        # echo "Adding <dependencyN> to npm's cache"
+        # npm cache add --loglevel-verbose <dependencyN>
+        # ```
+        ${
+            builtins.concatStringsSep "\n" (
+                map
+                (pkg:
+                    ''
+                        echo "Adding ${pkg.packageResolvedFetched} to npm's cache"
+                        npm cache add --loglevel-verbose ${pkg.packageResolvedFetched}
+                    ''
+                )
+                packageLockDependencies)
+        }
+
+        #########################################################
+        # Use `npm` to add the extra tarball dependencies from nix.
+        #########################################################
         # Note `npm` needs to modify these files, so we change the permissions
         chmod +777 package.json
         chmod +777 package-lock.json
-
-        mkdir -p $TMPDIR/cache
-        npm config set cache $TMPDIR/cache
-
-        # Create a directory to store the node dependencies provided by nix
-        NIX_NODE_DEPS_PATH=.nix-node-deps/
-        mkdir -p "$NIX_NODE_DEPS_PATH"
-
-        # Helper function to convert a package path to the path in
-        # `NIX_NODE_DEPS_PATH`
-        pkgPathToNixNodeDepsPath( ) { echo "$NIX_NODE_DEPS_PATH/$(basename "$1")"; }
 
         ${ if dependencies == [] then "" else
             ''
@@ -105,22 +127,30 @@ let
                 # Copying all `dependencies` into `.nix-nodes-deps/` i.e.,
                 # we run:
                 # ```
-                # echo "Copying <dependency1> and adding it to npm's cache"
-                # cp <dependency1> "$(pkgPathToNixNodeDepsPath <dependency1>)"
+                # echo "Adding <dependency1> npm's cache"
+                # ln -s <dependency1> .
                 # npm cache add <dependency1>
-                # echo "Copying <dependency2> and adding it to npm's cache"
-                # cp <dependency2> "$(pkgPathToNixNodeDepsPath <dependency2>)"
+                # echo "Adding <dependency2> npm's cache"
+                # ln -s <dependency2> .
                 # npm cache add <dependency2>
                 # ...
-                # echo "Copying <dependencyN> and adding it to npm's cache"
-                # cp <dependencyN> "$(pkgPathToNixNodeDepsPath <dependencyN>)"
+                # echo "Adding <dependency2> npm's cache"
+                # ln -s <dependencyN> .
                 # npm cache add <dependencyN>
                 # ```
+                # TODO(jaredponn): Why are we symlinking the stuff in the local
+                # directory and adding that to the cache? `npm` is a bit weird
+                # when it comes to adding dependencies on the local
+                # filesystem. It only allows relative paths, so by symlinking
+                # everything in the project root, `npm` seems to be able to find
+                # everything even when there are other npm modules which depend
+                # on other local files.
+                # This probably needs more investigation..
                 ${builtins.concatStringsSep "\n" (builtins.map (pkgPath: 
                     ''
-                        echo "Copying ${pkgPath} and adding it to npm's cache..."
-                        cp ${pkgPath} "$(pkgPathToNixNodeDepsPath "${pkgPath}")"
-                        npm cache add --loglevel=verbose "$(pkgPathToNixNodeDepsPath "${pkgPath}")"
+                        echo "Adding ${pkgPath} to npm's cache..."
+                        ln -s "${pkgPath}" .
+                        npm cache add --loglevel=verbose "$(basename "${pkgPath}")"
                     ''
                         ) dependencies)}
 
@@ -128,63 +158,70 @@ let
                 # ```
                 # npm install --save --package-lock-only <dependency1> <dependency2>  ... <dependencyN>
                 # ```
-                echo 'Running `npm install`...'
-                npm install --loglevel=verbose --save --package-lock-only ${builtins.concatStringsSep " " (builtins.map (pkgPath: ''$(pkgPathToNixNodeDepsPath "${pkgPath}")'') dependencies) }
+                echo 'Running `npm --package-lock-only install` for the tarballs from nix...'
+                npm install --loglevel=verbose --save --package-lock-only ${builtins.concatStringsSep " " (builtins.map (pkgPath: ''"$(basename "${pkgPath}")"'') dependencies) }
             ''
         }
 
         #########################################################
-        # Run `node2nix`
+        # Install all the dependencies
         #########################################################
-        echo 'Running `node2nix`...'
-        node2nix --input package.json --lock package-lock.json ${builtins.concatStringsSep " " extraFlags}
+        echo 'Running `npm install` to create node_modules...'
+        npm install
 
-        # Reset the permissions for  `package.json` and `package-lock.json` to
-        # read only for everyone.
+        #########################################################
+        # Patch shebangs from the installed packages
+        #########################################################
+
+        for PKGJSON in $(find node_modules -name package.json -type f)
+        do
+            PKGDIR=$(dirname "$PKGJSON")
+            for BIN in $(jq '(."bin"//{})[]' -r "$PKGJSON")
+            do
+                patchShebangs "$PKGDIR/$BIN"
+            done
+        done
+
+        # Reset the permissions as they were i.e., read only for everyone
         chmod =444 package.json
         chmod =444 package-lock.json
       '';
 
-  node2nixDevelop = node2nixExprs { extraFlags = [ "--development" ]; };
-  node2nixDevelopAttrs = ((import node2nixDevelop) { inherit nodejs pkgs; inherit (pkgs) system; });
-
   # Build the project (runs `npm run build`), and puts the entire output in the
   # nix store
-  project = node2nixDevelopAttrs.package.override
-    {
-      postInstall =
-        ''
-          npm run --loglevel=verbose build
-        '';
-    };
+  project =
+    npmProject.overrideAttrs (_self: super:
+      {
+        # Append the build command at the end.
+        buildCommand = super.buildCommand + "\n" +
+          ''
+            npm run --loglevel-verbose build
+          '';
+      });
 
-  shell = node2nixDevelopAttrs.shell.override
-    {
-      shellHook =
-        node2nixDevelopAttrs.shell.shellHook
-        +
-        ''
-          # Note: `node2nix` sets `$NODE_PATH` s.t. it is a single path.
-          echo 'Creating a symbolic link from `$NODE_PATH` to `node_modules`...'
-          ln -snf "$NODE_PATH" node_modules
 
-          # Run the provided `devShellHook`
-          ${devShellHook}
-        '';
-      buildInputs = node2nixDevelopAttrs.shell.buildInputs ++ devShellTools;
-    };
+  shell = pkgs.mkShell {
+    packages = project.buildInputs ++ devShellTools;
+
+    shellHook = ''
+      export NODE_PATH=${npmProject}/node_modules/
+      echo 'Creating a symbolic link from `$NODE_PATH` to `node_modules`...'
+
+      ln -snf "$NODE_PATH" node_modules
+
+      ${devShellHook}
+    '';
+  };
 
   # Creates a tarball of `project` using `npm pack` and puts it in the nix
   # store.
   npmPack = pkgs.stdenv.mkDerivation {
     buildInputs = [ nodejs ];
-    name = "${node2nixDevelopAttrs.args.name}.tgz";
+    name = "${name}.tgz";
 
-    # A glance at the generated nix expressions in `node2nixDevelop` will
-    # show why the following path is where the package really is.
-    src = "${project}/lib/node_modules/${node2nixDevelopAttrs.args.packageName}";
+    src = project;
     buildPhase = ''
-      cp -r "$src" .
+      cp -r "$src/." .
 
       # Why do we set `HOME=$TMPDIR`? This is because apparently `npm` will
       # attempt to do something like `mkdir $HOME` for which `$HOME` is not
@@ -198,16 +235,22 @@ let
   };
 
   # Run tests with `npm test`.
-  test = node2nixDevelopAttrs.package.override
-    {
-      postInstall =
-        ''
-          npm --loglevel=verbose test
-          rm -rf $out
-          touch $out
-        '';
-      buildInputs = node2nixDevelopAttrs.package.buildInputs ++ testTools;
-    };
+  test = pkgs.stdenv.mkDerivation {
+    buildInputs = project.buildInputs ++ testTools;
+    name = "${name}-test";
+
+    src = project;
+    buildPhase = ''
+      cp -r "$src/." .
+
+      npm --loglevel=verbose test
+    '';
+    installPhase = ''
+      touch $out
+    '';
+
+  };
+
 
 in
 {
@@ -218,7 +261,7 @@ in
   packages = {
     "${name}-typescript" = project;
     "${name}-typescript-tgz" = npmPack;
-    "${name}-typescript-node2nix" = node2nixDevelop;
+    "${name}-typescript-npm-project" = npmProject;
   };
 
   checks = {

--- a/extras/typescript/fetch-package-lock.nix
+++ b/extras/typescript/fetch-package-lock.nix
@@ -1,0 +1,53 @@
+# Given a `package-lock.json`, grabs all packages as tarballs.
+pkgs:
+{ src ? ./.
+, packageLock ? "${src}/package-lock.json"
+, ...
+}:
+let
+  # The plan.
+  # - The `package-lock.json` file contains a `packages` key which maps to an
+  # object that maps package locations to a package descriptor (object
+  # containing information about that package)
+  # - Those objects have as package descriptors (objects) containing fields
+  #   - `resolved`: the place where the package was actually resolved from e.g.
+  #           - url to tarball
+  #           - git URL with commit SHA,
+  #           - location of link target
+  #   - `integrity`: A sha512 or sha1 Standard Subresource Integrity string
+  #   for the artifact that was unpacked in this location
+  # See [1] for more details.
+  # - We're going to take all of those things under the `packages` key, and
+  # fetch the tarball ourselves manually, and create a nix derivation for each
+  # of the dependencies.
+  #
+  # References.
+  #   [1] https://docs.npmjs.com/cli/v10/configuring-npm/package-lock-json
+
+  packageLockAttrs = builtins.fromJSON (builtins.readFile packageLock);
+  # Note we remove the package location "" because that's the root project
+  packagesAttrs =
+    builtins.removeAttrs
+      (packageLockAttrs.packages or  { })
+      [ "" ];
+
+  # The type should be
+  # [ { packageLocation : string, packageDescriptor: set, packageResolvedFetched  } ]
+  dependencies =
+    builtins.map
+      (packageLocation:
+        {
+          packageLocation = packageLocation;
+          packageDescriptor = packagesAttrs.packageLocation;
+          packageResolvedFetched =
+            # TODO(jaredponn): Broken for non URL dependencies
+            pkgs.fetchurl {
+              url = packagesAttrs."${packageLocation}".resolved;
+              hash = packagesAttrs."${packageLocation}".integrity;
+            };
+        }
+      )
+      (builtins.attrNames packagesAttrs);
+
+in
+dependencies

--- a/runtimes/typescript/lbr-plutus/build.nix
+++ b/runtimes/typescript/lbr-plutus/build.nix
@@ -13,27 +13,6 @@
         };
     in
     {
-
-      packages = {
-        lbr-plutus-typescript = typescriptFlake.packages.lbr-plutus-typescript;
-        lbr-plutus-typescript-tgz = typescriptFlake.packages.lbr-plutus-typescript-tgz;
-        lbr-plutus-typescript-node2nix = typescriptFlake.packages.lbr-plutus-typescript-node2nix;
-      };
-
-      devShells = {
-        lbr-plutus-typescript = typescriptFlake.devShells.lbr-plutus-typescript;
-      };
-
-      checks = {
-        lbr-plutus-typescript-test = typescriptFlake.checks.lbr-plutus-typescript-test;
-      };
-
-      # TODO(jaredponn): for some reason, writing the more terse `inherit`
-      # seems to cause infinite recursion.
-      # ```
-      # inherit (typescriptFlake) packages checks devShells;
-      # ```
-      # So instead, we explicitly write out all the attribute names and what
-      # they are assigned to.
+      inherit (typescriptFlake) packages checks devShells;
     };
 }

--- a/runtimes/typescript/lbr-prelude/build.nix
+++ b/runtimes/typescript/lbr-prelude/build.nix
@@ -12,28 +12,7 @@
         };
     in
     {
-      packages = {
-        lbr-prelude-typescript = typescriptFlake.packages.lbr-prelude-typescript;
-        lbr-prelude-typescript-tgz = typescriptFlake.packages.lbr-prelude-typescript-tgz;
-        lbr-prelude-typescript-node2nix = typescriptFlake.packages.lbr-prelude-typescript-node2nix;
-      };
-
-      devShells =
-        {
-          lbr-prelude-typescript = typescriptFlake.devShells.lbr-prelude-typescript;
-        };
-
-      checks = {
-        lbr-prelude-typescript-test = typescriptFlake.checks.lbr-prelude-typescript-test;
-      };
-
-      # TODO(jaredponn): for some reason, writing the more terse `inherit`
-      # seems to cause infinite recursion.
-      # ```
-      # inherit (typescriptFlake) packages checks devShells;
-      # ```
-      # So instead, we explicitly write out all the attribute names and what
-      # they are assigned to.
+      inherit (typescriptFlake) packages checks devShells;
     };
 
 }


### PR DESCRIPTION
Surprisingly, one can scan the `package-lock.json` for URLS of tarballs for dependencies, then fetch those tarballs in a nix derivation, and manually add them into `npm`'s cache. Then, `npm install` will surprisingly manage to find everything in the cache without hitting the network.

# Future work
For now, this only supports grabbing things from the npm registry, and in the future we would like to support the complete set of allowed package-specs by `npm`.

Honestly, a better way forward would probably to cook up a proxy registry to the npm registry. override `npm` s.t. it always uses the proxy registry, and dump all the nix packages there. A brief glance suggests that https://verdaccio.org/ might be useful for this :^).