### PR TITLE
Allow adding nativeBuildInputs to Rust flake builder

### DIFF
--- a/extras/flake-rust.nix
+++ b/extras/flake-rust.nix
@@ -1,6 +1,18 @@
 pkgs:
 
-{ crane, src, crateName, rustVersion ? "latest", extraSources ? [ ], extraSourcesDir ? ".extras", data ? [ ], dataDir ? "data", devShellHook ? "", devShellTools ? [ ], testTools ? [ ] }:
+{ crane
+, src
+, crateName
+, rustVersion ? "latest"
+, nativeBuildInputs ? [ ]
+, extraSources ? [ ]
+, extraSourcesDir ? ".extras"
+, data ? [ ]
+, dataDir ? "data"
+, devShellHook ? ""
+, devShellTools ? [ ]
+, testTools ? [ ]
+}:
 let
   rustWithTools = pkgs.rust-bin.stable.${rustVersion}.default.override {
     extensions = [ "rustfmt" "rust-analyzer" "clippy" "rust-src" ];
@@ -41,6 +53,7 @@ let
       };
 
   commonArgs = {
+    inherit nativeBuildInputs;
     src = buildEnv;
     pname = crateName;
     strictDeps = true;

--- a/extras/flake-rust.nix
+++ b/extras/flake-rust.nix
@@ -89,6 +89,7 @@ let
 in
 {
   devShells."dev-${crateName}-rust" = craneLib.devShell {
+    buildInputs = nativeBuildInputs;
     packages = devShellTools;
     shellHook = ''
       ${linkExtraSources}


### PR DESCRIPTION
A `nativeBuildInputs` optional argument is added to `rustFlake`.
@jaredponn we will have to reflect these changes on the standalone flake repo.