### PR TITLE
Prepare lbr-prelude for publish

### DIFF
--- a/runtimes/rust/lbr-prelude-derive/Cargo.toml
+++ b/runtimes/rust/lbr-prelude-derive/Cargo.toml
@@ -13,6 +13,6 @@ syn = { version = "2.0.38", features = ["extra-traits"] }
 trybuild = { version = "1.0.49", features = ["diff"] }
 
 [dev-dependencies]
-lbr-prelude = { version = "0.1.0", path = ".extras/lbr-prelude", default-features = false }
+lbr-prelude = { path = ".extras/lbr-prelude", default-features = false }
 num-bigint = "0.4.4"
 serde_json = "1.0.107"

--- a/runtimes/rust/lbr-prelude-derive/Cargo.toml
+++ b/runtimes/rust/lbr-prelude-derive/Cargo.toml
@@ -2,6 +2,10 @@
 name = "lbr-prelude-derive"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
+homepage = "https://mlabs-haskell.github.io/lambda-buffers/"
+description = "Derive macros for the lambda-buffers Json trait"
+repository = "https://github.com/mlabs-haskell/lambda-buffers"
 
 [lib]
 proc-macro = true

--- a/runtimes/rust/lbr-prelude/Cargo.toml
+++ b/runtimes/rust/lbr-prelude/Cargo.toml
@@ -2,8 +2,10 @@
 name = "lbr-prelude"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+license = "Apache-2.0"
+homepage = "https://mlabs-haskell.github.io/lambda-buffers/"
+description = "Basic data types and utilities for lambda-buffers"
+repository = "https://github.com/mlabs-haskell/lambda-buffers"
 
 [dependencies]
 data-encoding = "2.4.0"

--- a/runtimes/rust/lbr-prelude/Cargo.toml
+++ b/runtimes/rust/lbr-prelude/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
 homepage = "https://mlabs-haskell.github.io/lambda-buffers/"
-description = "Basic data types and utilities for lambda-buffers"
+description = "LambdaBuffers runtime library for the Prelude schema."
 repository = "https://github.com/mlabs-haskell/lambda-buffers"
 
 [dependencies]


### PR DESCRIPTION
- Remove version flag from dev-dependencies to allow publishing without cyclic deps (see https://github.com/rust-lang/cargo/issues/4242)
- Add crate metadata
