### PR TITLE
Recursively copy symlinks instead of copying the symlink for lbf haskell

### DIFF
--- a/extras/lbf-nix/lbf-haskell.nix
+++ b/extras/lbf-nix/lbf-haskell.nix
@@ -100,7 +100,7 @@ let
 
       installPhase = ''
         mkdir -p $out;
-        cp -r autogen $out
+        cp -rL autogen $out
         cp ${name}.cabal $out/${name}.cabal;
         find $out;
 


### PR DESCRIPTION
Following some slack discussion, we noticed that on some people's computers we can't build certain derivations from lbf haskell because their computer couldn't follow a symlink.

So, this PR will copy the symlink recursively instead.