### PR TITLE
Add TS docs to SUMMARY.md

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -9,6 +9,7 @@
   - [LambdaBuffers to Purescript](purescript.md)
   - [LambdaBuffers to Plutarch](plutarch.md)
   - [LambdaBuffers to Rust](rust.md)
+  - [LambdaBuffers to Typescript](typescript.md)
 
 # Reference Guide
 
@@ -28,3 +29,4 @@
     - [Milestone 4: Project adoption](catalyst09-reports/milestone-3.md)
   - [Catalyst 10 reports](catalyst10-reports/README.md)
     - [Milestone 1: Rust support](catalyst10-reports/milestone-1.md)
+    - [Milestone 2: Javascript/Typescript support](catalyst10-reports/milestone-2.md)


### PR DESCRIPTION
The TS docs are missing from the generated mdbook output.

![image](https://github.com/mlabs-haskell/lambda-buffers/assets/27853460/98dcd013-2a92-46aa-a81c-a02df743ff60)


This PR hopes to fix that.

On my computer, in this PR, when I generate the `mdbook` I have: 
![image](https://github.com/mlabs-haskell/lambda-buffers/assets/27853460/67f714b8-1f1f-48c9-ad62-c83bbc784ccf)
