### PR TITLE
LamBuf modules depending on other generated modules

### DIFF
--- a/testsuites/lbt-plutus/api/DayTypes.lbf
+++ b/testsuites/lbt-plutus/api/DayTypes.lbf
@@ -1,0 +1,15 @@
+module DayTypes
+
+import Plutus.V1 (PlutusData)
+import Prelude (Eq, Json)
+import Days (Day)
+
+prod WorkDay = Day
+
+derive Eq WorkDay
+derive PlutusData WorkDay
+
+record FreeDay = { day : Day }
+
+derive Eq FreeDay
+derive PlutusData FreeDay

--- a/testsuites/lbt-plutus/api/Days.lbf
+++ b/testsuites/lbt-plutus/api/Days.lbf
@@ -7,13 +7,3 @@ sum Day = Monday | Tuesday | Wednesday | Thursday | Friday | Saturday | Sunday
 
 derive Eq Day
 derive PlutusData Day
-
-prod WorkDay = Day
-
-derive Eq WorkDay
-derive PlutusData WorkDay
-
-record FreeDay = { day : Day }
-
-derive Eq FreeDay
-derive PlutusData FreeDay

--- a/testsuites/lbt-plutus/api/build.nix
+++ b/testsuites/lbt-plutus/api/build.nix
@@ -1,42 +1,43 @@
 _: {
   perSystem = { config, ... }:
+    let
+      mainPkgArgs = lang: ({
+        name = "lbf-plutus-golden-api-${lang}";
+        src = ./.;
+        files = [ "Foo.lbf" "Foo/Bar.lbf" "DayTypes.lbf" ];
+      } // (if (lang == "typescript")
+      then {
+        npmExtraDependencies = [ config.packages.lbf-plutus-golden-api-days-typescript ];
+      }
+      else {
+        dependencies = [ "lbf-plutus-golden-api-days-${lang}" ];
+      }));
+
+      daysPkgArgs = lang: {
+        name = "lbf-plutus-golden-api-days-${lang}";
+        src = ./.;
+        files = [ "Days.lbf" ];
+      };
+    in
     {
       packages = {
-        lbf-plutus-golden-api-haskell = config.lbf-nix.lbfPlutusHaskell {
-          name = "lbf-plutus-golden-api";
-          src = ./.;
-          files = [ "Foo.lbf" "Foo/Bar.lbf" "Days.lbf" ];
-        };
+        lbf-plutus-golden-api-haskell = config.lbf-nix.lbfPlutusHaskell (mainPkgArgs "haskell");
+        lbf-plutus-golden-api-days-haskell = config.lbf-nix.lbfPlutusHaskell (daysPkgArgs "haskell");
 
-        lbf-plutus-golden-api-purescript = config.lbf-nix.lbfPlutusPurescript {
-          name = "lbf-plutus-golden-api";
-          src = ./.;
-          files = [ "Foo.lbf" "Foo/Bar.lbf" "Days.lbf" ];
-        };
+        lbf-plutus-golden-api-purescript = config.lbf-nix.lbfPlutusPurescript (mainPkgArgs "purescript");
+        lbf-plutus-golden-api-days-purescript = config.lbf-nix.lbfPlutusPurescript (daysPkgArgs "purescript");
 
-        lbf-plutus-golden-api-plutarch = config.lbf-nix.lbfPlutarch {
-          name = "lbf-plutus-plutarch-golden-api";
-          src = ./.;
-          files = [ "Foo.lbf" "Foo/Bar.lbf" "Days.lbf" ];
-        };
+        lbf-plutus-golden-api-plutarch = config.lbf-nix.lbfPlutarch (mainPkgArgs "plutarch");
+        lbf-plutus-golden-api-days-plutarch = config.lbf-nix.lbfPlutarch (daysPkgArgs "plutarch");
 
-        lbf-plutus-golden-api-plutustx = config.lbf-nix.lbfPlutusTx {
-          name = "lbf-plutus-plutustx-golden-api";
-          src = ./.;
-          files = [ "Foo.lbf" "Foo/Bar.lbf" "Days.lbf" ];
-        };
+        lbf-plutus-golden-api-plutustx = config.lbf-nix.lbfPlutusTx (mainPkgArgs "plutustx");
+        lbf-plutus-golden-api-days-plutustx = config.lbf-nix.lbfPlutusTx (daysPkgArgs "plutustx");
 
-        lbf-plutus-golden-api-rust = config.lbf-nix.lbfPlutusRust {
-          name = "lbf-plutus-rust-golden-api";
-          src = ./.;
-          files = [ "Foo.lbf" "Foo/Bar.lbf" "Days.lbf" ];
-        };
+        lbf-plutus-golden-api-rust = config.lbf-nix.lbfPlutusRust (mainPkgArgs "rust");
+        lbf-plutus-golden-api-days-rust = config.lbf-nix.lbfPlutusRust (daysPkgArgs "rust");
 
-        lbf-plutus-golden-api-typescript = config.lbf-nix.lbfPlutusTypescript {
-          name = "lbf-plutus-golden-api";
-          src = ./.;
-          files = [ "Foo.lbf" "Foo/Bar.lbf" "Days.lbf" ];
-        };
+        lbf-plutus-golden-api-typescript = config.lbf-nix.lbfPlutusTypescript (mainPkgArgs "typescript");
+        lbf-plutus-golden-api-days-typescript = config.lbf-nix.lbfPlutusTypescript (daysPkgArgs "typescript");
 
       };
     };

--- a/testsuites/lbt-plutus/lbt-plutus-haskell/build.nix
+++ b/testsuites/lbt-plutus/lbt-plutus-haskell/build.nix
@@ -14,6 +14,7 @@
           "${config.packages.lbf-prelude-haskell}"
           "${config.packages.lbr-plutus-haskell-src}"
           "${config.packages.lbf-plutus-haskell}"
+          "${config.packages.lbf-plutus-golden-api-days-haskell}"
           "${config.packages.lbf-plutus-golden-api-haskell}"
           "${config.packages.lbt-plutus-golden-haskell}"
         ];

--- a/testsuites/lbt-plutus/lbt-plutus-haskell/lbt-plutus-haskell.cabal
+++ b/testsuites/lbt-plutus/lbt-plutus-haskell/lbt-plutus-haskell.cabal
@@ -86,19 +86,20 @@ common common-language
 library
   import:          common-language
   build-depends:
-    , base                   >=4.16
-    , bytestring             >=0.11
-    , containers             >=0.6
-    , directory              >=1.3
-    , filepath               >=1.4
-    , lbf-plutus-golden-api
+    , base                                >=4.16
+    , bytestring                          >=0.11
+    , containers                          >=0.6
+    , directory                           >=1.3
+    , filepath                            >=1.4
+    , lbf-plutus-golden-api-days-haskell
+    , lbf-plutus-golden-api-haskell
     , lbr-plutus
     , lbr-prelude
-    , plutus-ledger-api      >=1.1
-    , plutus-tx              >=1.1
-    , split                  >=0.2
-    , tasty                  >=1.4
-    , tasty-hunit            >=0.10
+    , plutus-ledger-api                   >=1.1
+    , plutus-tx                           >=1.1
+    , split                               >=0.2
+    , tasty                               >=1.4
+    , tasty-hunit                         >=0.10
 
   hs-source-dirs:  src
   exposed-modules:
@@ -127,16 +128,17 @@ test-suite tests
   hs-source-dirs: test
   main-is:        Test.hs
   build-depends:
-    , base                    >=4.16
-    , hedgehog                >=1.2
-    , lbf-plutus-golden-api   >=0.1
+    , base                                >=4.16
+    , hedgehog                            >=1.2
+    , lbf-plutus-golden-api-days-haskell  >=0.1
+    , lbf-plutus-golden-api-haskell       >=0.1
     , lbr-plutus
     , lbr-prelude
     , lbt-plutus-golden-data
     , lbt-plutus-haskell
     , plutus-tx
-    , tasty                   >=1.4
-    , tasty-hedgehog          >=1.4
+    , tasty                               >=1.4
+    , tasty-hedgehog                      >=1.4
 
   other-modules:
     Test.LambdaBuffers.Runtime.Plutus.Generators.Correct

--- a/testsuites/lbt-plutus/lbt-plutus-haskell/src/Test/LambdaBuffers/Plutus/Golden.hs
+++ b/testsuites/lbt-plutus/lbt-plutus-haskell/src/Test/LambdaBuffers/Plutus/Golden.hs
@@ -53,7 +53,8 @@ module Test.LambdaBuffers.Plutus.Golden (
 ) where
 
 import Data.ByteString qualified as B
-import LambdaBuffers.Days (Day (Day'Friday, Day'Monday, Day'Saturday, Day'Sunday, Day'Thursday, Day'Tuesday, Day'Wednesday), FreeDay (FreeDay), WorkDay (WorkDay))
+import LambdaBuffers.DayTypes (FreeDay (FreeDay), WorkDay (WorkDay))
+import LambdaBuffers.Days (Day (Day'Friday, Day'Monday, Day'Saturday, Day'Sunday, Day'Thursday, Day'Tuesday, Day'Wednesday))
 import LambdaBuffers.Foo (A (A), B (B), C (C), D (D), FInt (FInt), GInt (GInt))
 import LambdaBuffers.Foo.Bar (F (F'Nil, F'Rec), FooComplicated (FooComplicated), FooProd (FooProd), FooRec (FooRec), FooSum (FooSum'Bar, FooSum'Baz, FooSum'Faz, FooSum'Foo, FooSum'Qax), G (G'Nil, G'Rec))
 import PlutusLedgerApi.V1 qualified as PlutusV1

--- a/testsuites/lbt-plutus/lbt-plutus-plutarch/build.nix
+++ b/testsuites/lbt-plutus/lbt-plutus-plutarch/build.nix
@@ -22,6 +22,8 @@
           # Golden api
           "${config.packages.lbf-plutus-golden-api-plutarch}"
           "${config.packages.lbf-plutus-golden-api-haskell}"
+          "${config.packages.lbf-plutus-golden-api-days-haskell}"
+          "${config.packages.lbf-plutus-golden-api-days-plutarch}"
           # Golden data
           "${config.packages.lbt-plutus-golden-haskell}"
           # Plutarch itself

--- a/testsuites/lbt-plutus/lbt-plutus-plutarch/lbt-plutus-plutarch.cabal
+++ b/testsuites/lbt-plutus/lbt-plutus-plutarch/lbt-plutus-plutarch.cabal
@@ -104,20 +104,22 @@ test-suite tests
   hs-source-dirs: test
   main-is:        Test.hs
   build-depends:
-    , base                            >=4.16
+    , base                                 >=4.16
     , lbf-plutus
-    , lbf-plutus-golden-api
+    , lbf-plutus-golden-api-days-haskell
+    , lbf-plutus-golden-api-days-plutarch
+    , lbf-plutus-golden-api-haskell
+    , lbf-plutus-golden-api-plutarch
     , lbf-plutus-plutarch
-    , lbf-plutus-plutarch-golden-api
     , lbf-prelude
     , lbf-prelude-plutarch
     , lbr-plutarch
     , lbr-plutus
     , lbt-plutus-plutarch
-    , plutarch                        >=1.3
-    , plutus-tx                       >=1.1
-    , tasty                           >=1.4
+    , plutarch                             >=1.3
+    , plutus-tx                            >=1.1
+    , tasty                                >=1.4
     , tasty-expected-failure
-    , tasty-hunit                     >=0.10
+    , tasty-hunit                          >=0.10
 
   other-modules:  Test.LambdaBuffers.Runtime.Plutarch.PlutusData

--- a/testsuites/lbt-plutus/lbt-plutus-plutarch/test/Test/LambdaBuffers/Runtime/Plutarch/PlutusData.hs
+++ b/testsuites/lbt-plutus/lbt-plutus-plutarch/test/Test/LambdaBuffers/Runtime/Plutarch/PlutusData.hs
@@ -3,6 +3,8 @@
 
 module Test.LambdaBuffers.Runtime.Plutarch.PlutusData (tests) where
 
+import LambdaBuffers.DayTypes qualified as HlDayTypes
+import LambdaBuffers.DayTypes.Plutarch qualified as PlDayTypes
 import LambdaBuffers.Days qualified as HlDays
 import LambdaBuffers.Days.Plutarch qualified as PlDays
 import LambdaBuffers.Foo qualified as HlFoo
@@ -44,8 +46,8 @@ transparentGoldens =
   testGroup
     "Transparent golden types"
     [ forallGoldens @HlDays.Day @PlDays.Day "Days.Day" 6
-    , forallGoldens @HlDays.FreeDay @PlDays.FreeDay "Days.FreeDay" 1
-    , forallGoldens @HlDays.WorkDay @PlDays.WorkDay "Days.WorkDay" 4
+    , forallGoldens @HlDayTypes.FreeDay @PlDayTypes.FreeDay "Days.FreeDay" 1
+    , forallGoldens @HlDayTypes.WorkDay @PlDayTypes.WorkDay "Days.WorkDay" 4
     , forallGoldens @HlFoo.A @PlFoo.A "Foo.A" 9
     , forallGoldens @HlFoo.B @PlFoo.B "Foo.B" 9
     , forallGoldens @HlFoo.C @PlFoo.C "Foo.C" 9

--- a/testsuites/lbt-plutus/lbt-plutus-plutustx/build.nix
+++ b/testsuites/lbt-plutus/lbt-plutus-plutustx/build.nix
@@ -14,6 +14,7 @@
           "${config.packages.lbf-prelude-plutustx}"
           "${config.packages.lbf-plutus-plutustx}"
           "${config.packages.lbf-plutus-golden-api-plutustx}"
+          "${config.packages.lbf-plutus-golden-api-days-plutustx}"
           "${config.packages.lbr-plutustx-src}"
 
           # LB Haskell backend imports (Prelude and Plutus)
@@ -22,6 +23,7 @@
           "${config.packages.lbr-plutus-haskell-src}"
           "${config.packages.lbf-plutus-haskell}"
           "${config.packages.lbf-plutus-golden-api-haskell}"
+          "${config.packages.lbf-plutus-golden-api-days-haskell}"
           "${config.packages.lbt-plutus-golden-haskell}"
 
           # Plutarch (just for script evaluation module)

--- a/testsuites/lbt-plutus/lbt-plutus-plutustx/lbt-plutus-plutustx.cabal
+++ b/testsuites/lbt-plutus/lbt-plutus-plutustx/lbt-plutus-plutustx.cabal
@@ -89,13 +89,15 @@ test-suite tests
   hs-source-dirs: test
   main-is:        Test.hs
   build-depends:
-    , base                            >=4.16
-    , bytestring                      >=0.11
-    , filepath                        >=1.4
-    , lbf-plutus                      >=0.1
-    , lbf-plutus-golden-api
+    , base                                 >=4.16
+    , bytestring                           >=0.11
+    , filepath                             >=1.4
+    , lbf-plutus                           >=0.1
+    , lbf-plutus-golden-api-days-haskell
+    , lbf-plutus-golden-api-days-plutustx
+    , lbf-plutus-golden-api-haskell
+    , lbf-plutus-golden-api-plutustx
     , lbf-plutus-plutustx
-    , lbf-plutus-plutustx-golden-api
     , lbf-prelude
     , lbf-prelude-plutustx
     , lbr-plutus
@@ -103,11 +105,11 @@ test-suite tests
     , lbr-prelude
     , lbt-plutus-golden-data
     , plutarch
-    , plutus-core                     >=1.20
-    , plutus-ledger-api               >=1.20
+    , plutus-core                          >=1.20
+    , plutus-ledger-api                    >=1.20
     , plutus-tx
     , plutus-tx-plugin
-    , tasty                           >=1.4
+    , tasty                                >=1.4
     , tasty-expected-failure
     , tasty-hunit
 

--- a/testsuites/lbt-plutus/lbt-plutus-plutustx/test/Test/LambdaBuffers/Runtime/PlutusTx/PlutusData.hs
+++ b/testsuites/lbt-plutus/lbt-plutus-plutustx/test/Test/LambdaBuffers/Runtime/PlutusTx/PlutusData.hs
@@ -5,6 +5,8 @@
 module Test.LambdaBuffers.Runtime.PlutusTx.PlutusData (tests) where
 
 import Data.ByteString qualified as B
+import LambdaBuffers.DayTypes qualified as HlDayTypes
+import LambdaBuffers.DayTypes.PlutusTx qualified as PlDayTypes
 import LambdaBuffers.Days qualified as HlDays
 import LambdaBuffers.Days.PlutusTx qualified as PlDays
 import LambdaBuffers.Foo qualified as HlFoo
@@ -47,8 +49,8 @@ transparentGoldens =
   testGroup
     "Transparent golden types"
     [ forallGoldens @HlDays.Day @PlDays.Day PlutusTx.dayCompiled "Days.Day" 6
-    , forallGoldens @HlDays.FreeDay @PlDays.FreeDay PlutusTx.freeDayCompiled "Days.FreeDay" 1
-    , forallGoldens @HlDays.WorkDay @PlDays.WorkDay PlutusTx.workDayCompiled "Days.WorkDay" 4
+    , forallGoldens @HlDayTypes.FreeDay @PlDayTypes.FreeDay PlutusTx.freeDayCompiled "Days.FreeDay" 1
+    , forallGoldens @HlDayTypes.WorkDay @PlDayTypes.WorkDay PlutusTx.workDayCompiled "Days.WorkDay" 4
     , forallGoldens @HlFoo.A @PlFoo.A PlutusTx.fooACompiled "Foo.A" 9
     , forallGoldens @HlFoo.B @PlFoo.B PlutusTx.fooBCompiled "Foo.B" 9
     , forallGoldens @HlFoo.C @PlFoo.C PlutusTx.fooCCompiled "Foo.C" 9

--- a/testsuites/lbt-plutus/lbt-plutus-plutustx/test/Test/LambdaBuffers/Runtime/PlutusTx/PlutusTx.hs
+++ b/testsuites/lbt-plutus/lbt-plutus-plutustx/test/Test/LambdaBuffers/Runtime/PlutusTx/PlutusTx.hs
@@ -58,7 +58,8 @@ module Test.LambdaBuffers.Runtime.PlutusTx.PlutusTx (
   scriptContext2Compiled,
 ) where
 
-import LambdaBuffers.Days.PlutusTx (Day, FreeDay, WorkDay)
+import LambdaBuffers.DayTypes.PlutusTx (FreeDay, WorkDay)
+import LambdaBuffers.Days.PlutusTx (Day)
 import LambdaBuffers.Foo.PlutusTx (A, B, C, D, E, FInt, GInt)
 import LambdaBuffers.Plutus.V2.PlutusTx qualified as PlutusV2
 import PlutusLedgerApi.V1 qualified as PlutusV1

--- a/testsuites/lbt-plutus/lbt-plutus-purescript/build.nix
+++ b/testsuites/lbt-plutus/lbt-plutus-purescript/build.nix
@@ -12,6 +12,7 @@
 
         extraSources = [
           config.packages.lbf-plutus-golden-api-purescript
+          config.packages.lbf-plutus-golden-api-days-purescript
           config.packages.lbf-prelude-purescript
           config.packages.lbf-plutus-purescript
           config.packages."purescript:lbr-prelude:src"

--- a/testsuites/lbt-plutus/lbt-plutus-purescript/data
+++ b/testsuites/lbt-plutus/lbt-plutus-purescript/data
@@ -1,0 +1,1 @@
+/nix/store/396y6jik1hy1cm6s4cmfq2avj0khisq9-data

--- a/testsuites/lbt-plutus/lbt-plutus-purescript/test/Test/LambdaBuffers/Runtime/Plutus/Generators/Correct.purs
+++ b/testsuites/lbt-plutus/lbt-plutus-purescript/test/Test/LambdaBuffers/Runtime/Plutus/Generators/Correct.purs
@@ -24,7 +24,8 @@ import JS.BigInt (BigInt)
 import JS.BigInt as BigInt
 import Data.Either (Either(Left, Right))
 import Data.Maybe (Maybe(Nothing, Just))
-import LambdaBuffers.Days (Day(Day'Friday, Day'Monday, Day'Saturday, Day'Sunday, Day'Thursday, Day'Tuesday, Day'Wednesday), FreeDay(FreeDay), WorkDay(WorkDay))
+import LambdaBuffers.Days (Day(Day'Friday, Day'Monday, Day'Saturday, Day'Sunday, Day'Thursday, Day'Tuesday, Day'Wednesday))
+import LambdaBuffers.DayTypes (FreeDay(FreeDay), WorkDay(WorkDay))
 import LambdaBuffers.Foo (A(A), B(B), C(C), D(D), FInt(..), GInt(..))
 import LambdaBuffers.Foo.Bar (F(..), FooComplicated(FooComplicated), FooProd(FooProd), FooRec(FooRec), FooSum(FooSum'Bar, FooSum'Baz, FooSum'Faz, FooSum'Foo, FooSum'Qax), G(..))
 import Test.LambdaBuffers.Plutus.Generators.Correct as Lbr

--- a/testsuites/lbt-plutus/lbt-plutus-rust/Cargo.lock
+++ b/testsuites/lbt-plutus/lbt-plutus-rust/Cargo.lock
@@ -128,10 +128,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "lbf-plutus-rust-golden-api"
+name = "lbf-plutus-golden-api-days-rust"
 version = "0.1.0"
 dependencies = [
  "lbf-plutus",
+ "lbf-prelude",
+ "lbr-prelude",
+ "num-bigint",
+ "plutus-ledger-api",
+ "serde_json",
+]
+
+[[package]]
+name = "lbf-plutus-golden-api-rust"
+version = "0.1.0"
+dependencies = [
+ "lbf-plutus",
+ "lbf-plutus-golden-api-days-rust",
  "lbf-prelude",
  "lbr-prelude",
  "num-bigint",
@@ -178,7 +191,8 @@ dependencies = [
 name = "lbt-plutus"
 version = "0.1.0"
 dependencies = [
- "lbf-plutus-rust-golden-api",
+ "lbf-plutus-golden-api-days-rust",
+ "lbf-plutus-golden-api-rust",
  "lbf-prelude",
  "lbr-prelude",
  "num-bigint",

--- a/testsuites/lbt-plutus/lbt-plutus-rust/Cargo.toml
+++ b/testsuites/lbt-plutus/lbt-plutus-rust/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 plutus-ledger-api = { version = "0.2.1", features = ["lbf"] }
-lbf-plutus-rust-golden-api = { path = ".extras/lbf-plutus-rust-golden-api-0.1.0" }
+lbf-plutus-golden-api-rust = { path = ".extras/lbf-plutus-golden-api-rust-0.1.0" }
+lbf-plutus-golden-api-days-rust = { path = ".extras/lbf-plutus-golden-api-days-rust-0.1.0" }
 lbf-prelude = { path = ".extras/lbf-prelude-0.1.0" }
 lbr-prelude = { version = "0.1.1" }
 serde_json = "1.0.108"

--- a/testsuites/lbt-plutus/lbt-plutus-rust/build.nix
+++ b/testsuites/lbt-plutus/lbt-plutus-rust/build.nix
@@ -9,6 +9,7 @@
 
           extraSources = [
             config.packages.lbf-plutus-golden-api-rust
+            config.packages.lbf-plutus-golden-api-days-rust
             config.packages.lbf-prelude-rust
             config.packages.lbf-plutus-rust
           ];

--- a/testsuites/lbt-plutus/lbt-plutus-typescript/build.nix
+++ b/testsuites/lbt-plutus/lbt-plutus-typescript/build.nix
@@ -8,6 +8,7 @@
           src = ./.;
           npmExtraDependencies = [
             config.packages.lbf-plutus-golden-api-typescript
+            config.packages.lbf-plutus-golden-api-days-typescript
           ];
 
           devShellTools = config.settings.shell.tools;

--- a/testsuites/lbt-plutus/lbt-plutus-typescript/package-lock.json
+++ b/testsuites/lbt-plutus/lbt-plutus-typescript/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "dependencies": {
         "lbf-plutus": "file:.extra-dependencies/lbf-plutus",
-        "lbf-plutus-golden-api": "file:.extra-dependencies/lbf-plutus-golden-api",
+        "lbf-plutus-golden-api-days-typescript": "file:.extra-dependencies/lbf-plutus-golden-api-days-typescript",
+        "lbf-plutus-golden-api-typescript": "file:.extra-dependencies/lbf-plutus-golden-api-typescript",
         "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
         "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
         "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
@@ -37,6 +38,7 @@
     },
     ".extra-dependencies/lbf-plutus-golden-api": {
       "version": "1.0.0",
+      "extraneous": true,
       "dependencies": {
         "lbf-plutus": "file:.extra-dependencies/lbf-plutus",
         "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
@@ -48,6 +50,203 @@
       "devDependencies": {
         "typescript": "^5.3.3"
       }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-days-typescript": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lbf-plutus": "file:.extra-dependencies/lbf-plutus",
+        "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
+        "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      },
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-days-typescript-0.1.0": {
+      "extraneous": true
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/lbf-plutus": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
+        "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/lbf-prelude": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/lbr-plutus": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/lbr-prelude": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/plutus-ledger-api": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/prelude": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "ISC"
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript": {
+      "version": "1.0.0",
+      "dependencies": {
+        "lbf-plutus": "file:.extra-dependencies/lbf-plutus",
+        "lbf-plutus-golden-api-days-typescript": "file:.extra-dependencies/lbf-plutus-golden-api-days-typescript",
+        "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
+        "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      },
+      "devDependencies": {
+        "typescript": "^5.3.3"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript-0.1.0": {
+      "extraneous": true
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-plutus": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
+        "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-plutus-golden-api-days-typescript": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "lbf-plutus": "file:.extra-dependencies/lbf-plutus",
+        "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
+        "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/lbf-plutus": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
+        "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/lbf-prelude": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/lbr-plutus": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/lbr-prelude": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/plutus-ledger-api": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-plutus-golden-api-days-typescript/.extra-dependencies/prelude": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "ISC"
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbf-prelude": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "dependencies": {
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbr-plutus": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/lbr-prelude": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/plutus-ledger-api": {
+      "version": "1.0.0",
+      "extraneous": true,
+      "license": "ISC",
+      "dependencies": {
+        "prelude": "file:.extra-dependencies/prelude"
+      }
+    },
+    ".extra-dependencies/lbf-plutus-golden-api-typescript/.extra-dependencies/prelude": {
+      "version": "1.0.1",
+      "extraneous": true,
+      "license": "ISC"
     },
     ".extra-dependencies/lbf-plutus-golden-api/.extra-dependencies/lbf-plutus": {
       "version": "1.0.0",
@@ -239,10 +438,10 @@
         "prelude": "file:.extra-dependencies/prelude"
       },
       "devDependencies": {
-        "@types/node": "*",
-        "fast-check": "*",
-        "typedoc": "*",
-        "typescript": "*"
+        "@types/node": "^20.8.10",
+        "fast-check": "^3.14.0",
+        "typedoc": "^0.25.4",
+        "typescript": "^5.2.2"
       }
     },
     ".extra-dependencies/plutus-ledger-api/.extra-dependencies/prelude": {
@@ -260,10 +459,10 @@
       "version": "1.0.1",
       "license": "ISC",
       "devDependencies": {
-        "@types/node": "*",
-        "fast-check": "*",
-        "typedoc": "*",
-        "typescript": "*"
+        "@types/node": "^20.8.10",
+        "fast-check": "^3.15.1",
+        "typedoc": "^0.25.4",
+        "typescript": "^5.2.2"
       }
     },
     "node_modules/@types/node": {
@@ -328,8 +527,12 @@
       "resolved": ".extra-dependencies/lbf-plutus",
       "link": true
     },
-    "node_modules/lbf-plutus-golden-api": {
-      "resolved": ".extra-dependencies/lbf-plutus-golden-api",
+    "node_modules/lbf-plutus-golden-api-days-typescript": {
+      "resolved": ".extra-dependencies/lbf-plutus-golden-api-days-typescript",
+      "link": true
+    },
+    "node_modules/lbf-plutus-golden-api-typescript": {
+      "resolved": ".extra-dependencies/lbf-plutus-golden-api-typescript",
       "link": true
     },
     "node_modules/lbf-prelude": {
@@ -523,10 +726,23 @@
         "typescript": "^5.3.3"
       }
     },
-    "lbf-plutus-golden-api": {
-      "version": "file:.extra-dependencies/lbf-plutus-golden-api",
+    "lbf-plutus-golden-api-days-typescript": {
+      "version": "file:.extra-dependencies/lbf-plutus-golden-api-days-typescript",
       "requires": {
         "lbf-plutus": "file:.extra-dependencies/lbf-plutus",
+        "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
+        "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
+        "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
+        "plutus-ledger-api": "file:.extra-dependencies/plutus-ledger-api",
+        "prelude": "file:.extra-dependencies/prelude",
+        "typescript": "^5.3.3"
+      }
+    },
+    "lbf-plutus-golden-api-typescript": {
+      "version": "file:.extra-dependencies/lbf-plutus-golden-api-typescript",
+      "requires": {
+        "lbf-plutus": "file:.extra-dependencies/lbf-plutus",
+        "lbf-plutus-golden-api-days-typescript": "file:.extra-dependencies/lbf-plutus-golden-api-days-typescript",
         "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
         "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
         "lbr-prelude": "file:.extra-dependencies/lbr-prelude",
@@ -585,20 +801,20 @@
     "plutus-ledger-api": {
       "version": "file:.extra-dependencies/plutus-ledger-api",
       "requires": {
-        "@types/node": "*",
-        "fast-check": "*",
+        "@types/node": "^20.8.10",
+        "fast-check": "^3.14.0",
         "prelude": "file:.extra-dependencies/prelude",
-        "typedoc": "*",
-        "typescript": "*"
+        "typedoc": "^0.25.4",
+        "typescript": "^5.2.2"
       }
     },
     "prelude": {
       "version": "file:.extra-dependencies/prelude",
       "requires": {
-        "@types/node": "*",
-        "fast-check": "*",
-        "typedoc": "*",
-        "typescript": "*"
+        "@types/node": "^20.8.10",
+        "fast-check": "^3.15.1",
+        "typedoc": "^0.25.4",
+        "typescript": "^5.2.2"
       }
     },
     "pure-rand": {

--- a/testsuites/lbt-plutus/lbt-plutus-typescript/package.json
+++ b/testsuites/lbt-plutus/lbt-plutus-typescript/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "lbf-plutus": "file:.extra-dependencies/lbf-plutus",
-    "lbf-plutus-golden-api": "file:.extra-dependencies/lbf-plutus-golden-api",
+    "lbf-plutus-golden-api-typescript": "file:.extra-dependencies/lbf-plutus-golden-api-typescript",
+    "lbf-plutus-golden-api-days-typescript": "file:.extra-dependencies/lbf-plutus-golden-api-days-typescript",
     "lbf-prelude": "file:.extra-dependencies/lbf-prelude",
     "lbr-plutus": "file:.extra-dependencies/lbr-plutus",
     "lbr-prelude": "file:.extra-dependencies/lbr-prelude",

--- a/testsuites/lbt-plutus/lbt-plutus-typescript/src/Goldens.ts
+++ b/testsuites/lbt-plutus/lbt-plutus-typescript/src/Goldens.ts
@@ -5,9 +5,10 @@ import * as LbrPlutusV2 from "lbr-plutus/V2.js";
 import * as PlaV1 from "plutus-ledger-api/V1.js";
 import * as PlaMap from "plutus-ledger-api/AssocMap.js";
 
-import * as LbfFooBar from "lbf-plutus-golden-api/LambdaBuffers/Foo/Bar.mjs";
-import * as LbfFoo from "lbf-plutus-golden-api/LambdaBuffers/Foo.mjs";
-import * as LbfDays from "lbf-plutus-golden-api/LambdaBuffers/Days.mjs";
+import * as LbfFooBar from "lbf-plutus-golden-api-typescript/LambdaBuffers/Foo/Bar.mjs";
+import * as LbfFoo from "lbf-plutus-golden-api-typescript/LambdaBuffers/Foo.mjs";
+import * as LbfDays from "lbf-plutus-golden-api-days-typescript/LambdaBuffers/Days.mjs";
+import * as LbfDayTypes from "lbf-plutus-golden-api-typescript/LambdaBuffers/DayTypes.mjs";
 
 /**
  * Hard coded bytes for testing
@@ -1089,7 +1090,7 @@ export function dayGoldens(): LbfDays.Day[] {
 /**
  * Hard coded {@link WorkDay} tests
  */
-export function workDayGoldens(): LbfDays.WorkDay[] {
+export function workDayGoldens(): LbfDayTypes.WorkDay[] {
   return [
     { name: "Monday" },
     { name: "Tuesday" },
@@ -1104,7 +1105,7 @@ export function workDayGoldens(): LbfDays.WorkDay[] {
 /**
  * Hard coded {@link FreeDay} tests
  */
-export function freeDayGoldens(): LbfDays.FreeDay[] {
+export function freeDayGoldens(): LbfDayTypes.FreeDay[] {
   return [{ day: { name: "Saturday" } }, { day: { name: "Sunday" } }];
 }
 

--- a/testsuites/lbt-plutus/lbt-plutus-typescript/src/PlutusData-test.ts
+++ b/testsuites/lbt-plutus/lbt-plutus-typescript/src/PlutusData-test.ts
@@ -7,8 +7,9 @@ import * as Goldens from "./Goldens.js";
 import * as LbrPrelude from "lbr-prelude";
 import * as PreludeJson from "prelude/Json.js";
 
-import * as LbfFoo from "lbf-plutus-golden-api/LambdaBuffers/Foo.mjs";
-import * as LbfDays from "lbf-plutus-golden-api/LambdaBuffers/Days.mjs";
+import * as LbfFoo from "lbf-plutus-golden-api-typescript/LambdaBuffers/Foo.mjs";
+import * as LbfDays from "lbf-plutus-golden-api-days-typescript/LambdaBuffers/Days.mjs";
+import * as LbfDayTypes from "lbf-plutus-golden-api-typescript/LambdaBuffers/DayTypes.mjs";
 
 import * as LbrPlutusV1 from "lbr-plutus/V1.js";
 import * as LbrPlutusV2 from "lbr-plutus/V2.js";
@@ -172,12 +173,12 @@ describe("PlutusData tests (toJson . toPlutusData . fromPlutusData . fromJson)",
         Utils.mkFromToAssertGolden(
           PreludeJson.parseJson,
           (v) =>
-            LbrPlutusV1.IsPlutusData[LbfDays.WorkDay].fromData(
+            LbrPlutusV1.IsPlutusData[LbfDayTypes.WorkDay].fromData(
               LbrPrelude.Json[LbrPlutusV1.PlutusData].fromJson(v),
             ),
           (v) =>
             LbrPrelude.Json[LbrPlutusV1.PlutusData].toJson(
-              LbrPlutusV1.IsPlutusData[LbfDays.WorkDay].toData(v),
+              LbrPlutusV1.IsPlutusData[LbfDayTypes.WorkDay].toData(v),
             ),
           PreludeJson.stringify,
         ),
@@ -192,12 +193,12 @@ describe("PlutusData tests (toJson . toPlutusData . fromPlutusData . fromJson)",
         Utils.mkFromToAssertGolden(
           PreludeJson.parseJson,
           (v) =>
-            LbrPlutusV1.IsPlutusData[LbfDays.FreeDay].fromData(
+            LbrPlutusV1.IsPlutusData[LbfDayTypes.FreeDay].fromData(
               LbrPrelude.Json[LbrPlutusV1.PlutusData].fromJson(v),
             ),
           (v) =>
             LbrPrelude.Json[LbrPlutusV1.PlutusData].toJson(
-              LbrPlutusV1.IsPlutusData[LbfDays.FreeDay].toData(v),
+              LbrPlutusV1.IsPlutusData[LbfDayTypes.FreeDay].toData(v),
             ),
           PreludeJson.stringify,
         ),


### PR DESCRIPTION
I modified the testsuite to include this kind of dependency:
`lbf-plutus-golden-api` depends on `lbf-plutus-golden-api-days`

It looks like both TypeScript and Rust don't handle this use case.