### PR TITLE
Rust's phantom handling fixes

### DIFF
--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Backend/Plutarch/Derive.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Backend/Plutarch/Derive.hs
@@ -81,7 +81,7 @@ printPEqInstanceDef :: MonadHaskellBackend t m => PC.Ty -> Doc ann -> m (Doc ann
 printPEqInstanceDef ty implDefDoc = do
   Print.importClass PlRefs.peqQClassName
   Print.importClass PlRefs.pisDataQClassName
-  let freeVars = Haskell.collectTyVars ty
+  let freeVars = PC.collectTyVars ty
   headDoc <- Haskell.printConstraint PlRefs.peqQClassName ty
   case freeVars of
     [] -> return $ "instance" <+> headDoc <+> "where" <> hardline <> space <> space <> implDefDoc
@@ -170,7 +170,7 @@ printPlutusTypeInstanceDef ty implDefDoc = do
   Print.importType PlRefs.pdataQTyName
   headDoc <- Haskell.printConstraint PlRefs.plutusTypeQClassName ty
   tyDoc <- Haskell.printTyInner ty
-  let freeVars = Haskell.collectTyVars ty
+  let freeVars = PC.collectTyVars ty
       pinnerDefDoc = "type PInner" <+> tyDoc <+> "=" <+> Haskell.printHsQTyName PlRefs.pdataQTyName
   case freeVars of
     [] ->
@@ -272,7 +272,7 @@ printPTryFromPAsDataInstanceDef ty implDefDoc = do
         Haskell.printHsQClassName PlRefs.ptryFromQClassName
           <+> Haskell.printHsQTyName PlRefs.pdataQTyName
           <+> parens (Haskell.printHsQTyName PlRefs.pasDataQTyName <+> tyDoc)
-      freeVars = Haskell.collectTyVars ty
+      freeVars = PC.collectTyVars ty
       pinnerDefDoc =
         "type PTryFromExcess"
           <+> Haskell.printHsQTyName PlRefs.pdataQTyName
@@ -332,7 +332,7 @@ printPTryFromInstanceDef ty = do
         Haskell.printHsQClassName PlRefs.ptryFromQClassName
           <+> Haskell.printHsQTyName PlRefs.pdataQTyName
           <+> tyDoc
-      freeVars = Haskell.collectTyVars ty
+      freeVars = PC.collectTyVars ty
 
       pinnerDefDoc =
         "type PTryFromExcess"

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/InstanceDef.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Haskell/Print/InstanceDef.hs
@@ -1,9 +1,5 @@
-module LambdaBuffers.Codegen.Haskell.Print.InstanceDef (printInstanceDef, printConstraint, collectTyVars, printInstanceContext, printInstanceContext', printConstraint') where
+module LambdaBuffers.Codegen.Haskell.Print.InstanceDef (printInstanceDef, printConstraint, printInstanceContext, printInstanceContext', printConstraint') where
 
-import Control.Lens (view)
-import Data.Foldable (Foldable (toList))
-import Data.Set (Set)
-import Data.Set qualified as Set
 import LambdaBuffers.Codegen.Haskell.Backend (MonadHaskellBackend)
 import LambdaBuffers.Codegen.Haskell.Print.Syntax qualified as HsSyntax
 import LambdaBuffers.Codegen.Haskell.Print.TyDef (printTyInner)
@@ -23,7 +19,7 @@ instance (SomeClass a, SomeClass b, SomeClass c) => SomeClass (SomeTy a b c) whe
 -}
 printInstanceDef :: forall t m ann. MonadHaskellBackend t m => HsSyntax.QClassName -> PC.Ty -> m (Doc ann -> m (Doc ann))
 printInstanceDef hsQClassName ty = do
-  let freeVars = collectTyVars ty
+  let freeVars = PC.collectTyVars ty
   headDoc <- printConstraint hsQClassName ty
   return $ case freeVars of
     [] -> \implDoc -> return $ "instance" <+> headDoc <+> "where" <> hardline <> space <> space <> implDoc
@@ -47,14 +43,3 @@ printConstraint' qcn tys = do
   let crefDoc = HsSyntax.printHsQClassName qcn
   tyDocs <- traverse printTyInner tys
   return $ crefDoc <+> hsep tyDocs
-
-collectTyVars :: PC.Ty -> [PC.Ty]
-collectTyVars = fmap (`PC.withInfoLess` (PC.TyVarI . PC.TyVar)) . toList . collectVars
-
-collectVars :: PC.Ty -> Set (PC.InfoLess PC.VarName)
-collectVars = collectVars' mempty
-
-collectVars' :: Set (PC.InfoLess PC.VarName) -> PC.Ty -> Set (PC.InfoLess PC.VarName)
-collectVars' collected (PC.TyVarI tv) = Set.insert (PC.mkInfoLess . view #varName $ tv) collected
-collectVars' collected (PC.TyAppI (PC.TyApp _ args _)) = collected `Set.union` (Set.unions . fmap collectVars $ args)
-collectVars' collected _ = collected

--- a/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Rust/Print/TyDef.hs
+++ b/lambda-buffers-codegen/src/LambdaBuffers/Codegen/Rust/Print/TyDef.hs
@@ -150,7 +150,7 @@ printRec parentTyN tyArgs (PC.Record fields _) = do
   let iTyDefs = indexTyDefs ci
   mn <- asks (view $ Print.ctxModule . #moduleName)
   let phantomTyArgs = collectPhantomTyArgs iTyDefs mn parentTyN (recFieldTys fields) tyArgs
-      phantomFields = printPhantomDataField <$> phantomTyArgs
+      phantomFields = pub . printPhantomDataField <$> phantomTyArgs
   if null fields && null phantomTyArgs
     then return semi
     else do

--- a/lambda-buffers-compiler/lambda-buffers-compiler.cabal
+++ b/lambda-buffers-compiler/lambda-buffers-compiler.cabal
@@ -199,6 +199,7 @@ test-suite tests
     Test.LambdaBuffers.Compiler.LamTy
     Test.LambdaBuffers.Compiler.MiniLog
     Test.LambdaBuffers.Compiler.Mutation
+    Test.LambdaBuffers.Compiler.Phantoms
     Test.LambdaBuffers.Compiler.TypeClassCheck
     Test.LambdaBuffers.Compiler.Utils
     Test.LambdaBuffers.Compiler.Utils.Golden

--- a/lambda-buffers-compiler/src/LambdaBuffers/Compiler/LamTy.hs
+++ b/lambda-buffers-compiler/src/LambdaBuffers/Compiler/LamTy.hs
@@ -1,4 +1,4 @@
-module LambdaBuffers.Compiler.LamTy (LT.Ty (..), LT.fromTy, LT.eval, LT.runEval, LT.runEval', LT.prettyTy) where
+module LambdaBuffers.Compiler.LamTy (LT.Ty (..), LT.fromTy, LT.eval, LT.runEval, LT.runEval', LT.prettyTy, LT.runEvalWithGas) where
 
 import LambdaBuffers.Compiler.LamTy.Eval qualified as LT
 import LambdaBuffers.Compiler.LamTy.Pretty qualified as LT

--- a/lambda-buffers-compiler/test/Test.hs
+++ b/lambda-buffers-compiler/test/Test.hs
@@ -6,6 +6,7 @@ import Test.LambdaBuffers.Compiler qualified as LBC
 import Test.LambdaBuffers.Compiler.ClassClosure qualified as ClassClosure
 import Test.LambdaBuffers.Compiler.LamTy qualified as LT
 import Test.LambdaBuffers.Compiler.MiniLog qualified as ML
+import Test.LambdaBuffers.Compiler.Phantoms qualified as Phantoms
 import Test.LambdaBuffers.Compiler.TypeClassCheck qualified as TC
 import Test.Tasty (defaultMain, testGroup)
 
@@ -21,4 +22,5 @@ main =
       , ML.test
       , TC.test
       , ClassClosure.tests
+      , Phantoms.test
       ]

--- a/lambda-buffers-compiler/test/Test/LambdaBuffers/Compiler/Phantoms.hs
+++ b/lambda-buffers-compiler/test/Test/LambdaBuffers/Compiler/Phantoms.hs
@@ -1,0 +1,28 @@
+module Test.LambdaBuffers.Compiler.Phantoms (test) where
+
+import LambdaBuffers.ProtoCompat qualified as PC
+import LambdaBuffers.ProtoCompat.Utils (collectPhantomTyArgs)
+import Test.LambdaBuffers.ProtoCompat.Utils qualified as U
+import Test.Tasty (TestTree, adjustOption, testGroup)
+import Test.Tasty.HUnit (testCase, (@?=))
+import Test.Tasty.Hedgehog qualified as H
+
+test :: TestTree
+test =
+  adjustOption (\_ -> H.HedgehogTestLimit $ Just 1000) $
+    testGroup
+      "Phantoms checks"
+      [ testCase "phantomA" $ phantoms U.td'phantomA @?= ["a"]
+      , testCase "phantomB" $ phantoms U.td'phantomB @?= ["a", "b"]
+      , testCase "phantomC" $ phantoms U.td'phantomC @?= ["a"]
+      , testCase "phantomD" $ phantoms U.td'phantomD @?= ["a", "b"]
+      , testCase "phantomE" $ phantoms U.td'phantomE @?= ["a"]
+      , testCase "phantomF" $ phantoms U.td'phantomF @?= ["a", "b"]
+      , testCase "Either" $ phantoms U.td'either @?= []
+      , testCase "Either opaque" $ phantoms U.td'eitherO @?= []
+      , testCase "List" $ phantoms U.td'list @?= []
+      , testCase "Maybe" $ phantoms U.td'maybe @?= []
+      , testCase "Maybe opaque" $ phantoms U.td'maybeO @?= []
+      ]
+  where
+    phantoms = fmap ((\(PC.VarName name _) -> name) . PC.argName) . collectPhantomTyArgs

--- a/lambda-buffers-compiler/test/Test/LambdaBuffers/Compiler/TypeClassCheck.hs
+++ b/lambda-buffers-compiler/test/Test/LambdaBuffers/Compiler/TypeClassCheck.hs
@@ -762,7 +762,7 @@ fails :: TestName -> PC.CompilerInput -> TestTree
 fails title ci =
   Golden.fails
     goldensDir
-    (\tdir -> let fn = tdir </> "compiler_error" <.> "textproto" in (,) <$> (PbText.readMessageOrDie <$> Text.readFile fn) <*> pure fn)
+    (\tdir -> let fn = tdir </> "compiler_error" <.> "textproto" in ((,) . PbText.readMessageOrDie <$> Text.readFile fn) <*> pure fn)
     (\otherFn gotErr -> Text.writeFile otherFn (Text.pack . show $ PbText.pprintMessage gotErr))
     title
     (fst $ TC.runCheck' ci)

--- a/lambda-buffers-compiler/test/Test/LambdaBuffers/ProtoCompat/Utils.hs
+++ b/lambda-buffers-compiler/test/Test/LambdaBuffers/ProtoCompat/Utils.hs
@@ -29,6 +29,12 @@ module Test.LambdaBuffers.ProtoCompat.Utils (
   qcln',
   mod'prelude'only'eq,
   mod'prelude'noclass,
+  td'phantomA,
+  td'phantomB,
+  td'phantomC,
+  td'phantomD,
+  td'phantomE,
+  td'phantomF,
 ) where
 
 import Control.Lens ((^.))
@@ -181,6 +187,24 @@ td'list :: PC.TyDef
 td'list = td "List" (abs ["a"] $ sum [("Nil", []), ("Cons", [tv "a", lr "List" @ [tv "a"]])])
 td'listO :: PC.TyDef
 td'listO = td "List" (abs ["a"] opq)
+
+td'phantomA :: PC.TyDef
+td'phantomA = td "PhantomA" (abs ["a"] $ sum [("A", [lr "Int", lr "Int"]), ("B", [lr "Int", lr "Int"])])
+
+td'phantomB :: PC.TyDef
+td'phantomB = td "PhantomB" (abs ["a", "b"] $ sum [("A", [lr "Int", lr "Int"]), ("B", [lr "Int", lr "Int"])])
+
+td'phantomC :: PC.TyDef
+td'phantomC = td "PhantomC" (abs ["a"] $ prod' [lr "Int", lr "Int"])
+
+td'phantomD :: PC.TyDef
+td'phantomD = td "PhantomD" (abs ["a", "b"] $ prod' [lr "Int", lr "Int"])
+
+td'phantomE :: PC.TyDef
+td'phantomE = td "PhantomE" (abs ["a"] $ recrd [("foo", lr "Int"), ("bar", lr "Int")])
+
+td'phantomF :: PC.TyDef
+td'phantomF = td "PhantomF" (abs ["a", "b"] $ recrd [("foo", lr "Int"), ("bar", lr "Int")])
 
 -- | Some class definitions.
 cd'eq :: PC.ClassDef

--- a/settings.nix
+++ b/settings.nix
@@ -24,7 +24,8 @@
 
             index-state = lib.mkOption {
               type = lib.types.str;
-              description = "Hackage index state to use when making a haskell.nix build environment";
+              description = "Hackage index state to use when making a haskell.nix
+ build environment";
             };
 
             compiler-nix-name = lib.mkOption {
@@ -50,6 +51,8 @@
 
               tools = [
 
+                pkgs.haskellPackages.fourmolu
+                pkgs.haskellPackages.hlint
                 pkgs.haskellPackages.apply-refact
 
                 pkgs.nil


### PR DESCRIPTION
DONE
 - [x] Record TyDef printing adds `pub` to phantom record fields
 - [ ] Phantom analysis bug fix is still unresolved (https://github.com/mlabs-haskell/lambda-buffers/issues/237)