### PR TITLE
Added PlutusTx and Typescript to documentation for seeing how LambdaBuffers is transpiled to other languages

### DIFF
--- a/docs/using-lambdabuffers.md
+++ b/docs/using-lambdabuffers.md
@@ -9,6 +9,8 @@ To set up a project with LambdaBuffers and multi-language stack, refer to our de
 To see, how LambdaBuffers code is transpiled into other languages, see:
 
 - [LambdaBuffers to Haskell](haskell.md)
+- [LambdaBuffers to PlutusTx](plutustx.md)
 - [LambdaBuffers to Purescript](purescript.md)
 - [LambdaBuffers to Plutarch](plutarch.md)
 - [LambdaBuffers to Rust](rust.md)
+- [LambdaBuffers to Typescript](typescript.md)


### PR DESCRIPTION
This PR
- [x] Includes PlutusTx and TypeScript in a documentation chapter where it appears to be missing.