### PR TITLE
Replace `name` attribute for nix derivations of .lbf schemas with `pname` and `version` attributes

### DIFF
--- a/libs/build.nix
+++ b/libs/build.nix
@@ -5,7 +5,8 @@
 
     packages = {
       lbf-prelude = pkgs.stdenv.mkDerivation {
-        name = "lbf-prelude";
+        pname = "lbf-prelude";
+        version = "1.0.0";
         src = ./lbf-prelude;
         phases = "installPhase";
         installPhase = "ln -s $src $out";
@@ -64,7 +65,8 @@
       };
 
       lbf-plutus = pkgs.stdenv.mkDerivation {
-        name = "lbf-plutus";
+        pname = "lbf-plutus";
+        version = "1.0.0";
         src = ./lbf-plutus;
         phases = "installPhase";
         installPhase = "ln -s $src $out";


### PR DESCRIPTION
This PR:
- [x] Gives the nix derivations for the `.lbf` schemas a version

Remarks:

This makes the schemas match the version numbers in the CHANGELOG.md 
- https://github.com/mlabs-haskell/lambda-buffers/blob/main/CHANGELOG.md?plain=1#L54
- https://github.com/mlabs-haskell/lambda-buffers/blob/main/CHANGELOG.md?plain=1#L72

This method of versioning the nix derivation follows the convention in with `stdenv` here https://nixos.org/manual/nixpkgs/stable/#sec-using-stdenv