### PR TITLE
DO NOT MERGE THIS 

### DIFF
--- a/extras/lbf-nix/lbf-haskell.nix
+++ b/extras/lbf-nix/lbf-haskell.nix
@@ -85,6 +85,21 @@ let
       '';
     };
 
+  cabalProject =
+    opts:
+    with (lbfHaskellOpts opts);
+    pkgs.writeTextFile {
+      name = "lambda-buffers-cabal-project";
+      text = ''
+        packages: ./${name}.cabal
+
+        source-repository-package
+          type: git
+          location: https://github.com/mlabs-haskell/hbls-need-push-access.git
+          tag: 6b92e81481f5409c624e1b9b22eefc7d3abd81fb
+      '';
+    };
+
   build =
     opts:
     with (lbfHaskellOpts opts);
@@ -116,12 +131,14 @@ let
         cat ${cabalTemplate opts} \
             | sed -r "s/<EXPOSED_MODULES>/$EXPOSED_MODULES/" \
             | sed -r "s/<DEPS>/$DEPS/" > ${name}.cabal;
+        cat ${cabalProject opts} > cabal.project;
       '';
 
       installPhase = ''
         mkdir -p $out;
-        cp -rL autogen $out
+        cp -rL autogen $out;
         cp ${name}.cabal $out/${name}.cabal;
+        cp cabal.project $out/cabal.project;
         find $out;
 
         cp build.json $buildjson;

--- a/lambda-buffers-codegen/data/haskell-prelude-base.json
+++ b/lambda-buffers-codegen/data/haskell-prelude-base.json
@@ -49,6 +49,16 @@
       "base",
       "Prelude",
       "Bool"
+    ],
+    "Prelude.G1Element": [
+      "hbls-need-push-access",
+      "HBLS",
+      "G1Point"
+    ],
+    "Prelude.G2Element": [
+      "hbls-need-push-access",
+      "HBLS",
+      "G2Point"
     ]
   },
   "classesConfig": {

--- a/lambda-buffers-codegen/data/plutarch-prelude.json
+++ b/lambda-buffers-codegen/data/plutarch-prelude.json
@@ -49,6 +49,16 @@
       "lbr-plutarch",
       "LambdaBuffers.Runtime.Plutarch",
       "PSet"
+    ],
+    "Prelude.G1Element": [
+      "plutarch",
+      "Plutarch.Builtin.BLS",
+      "PBuiltinBLS12_381_G1_Element"
+    ],
+    "Prelude.G2Element": [
+      "plutarch",
+      "Plutarch.Builtin.BLS",
+      "PBuiltinBLS12_381_G2_Element"
     ]
   },
   "classesConfig": {

--- a/lambda-buffers-codegen/data/plutustx-prelude.json
+++ b/lambda-buffers-codegen/data/plutustx-prelude.json
@@ -49,6 +49,16 @@
         "lbr-plutustx",
         "LambdaBuffers.Runtime.PlutusTx.NotImplemented",
         "Set"
+    ],
+    "Prelude.G1Element": [
+      "plutus-tx",
+      "PlutusTx.Builtins",
+      "BuiltinBLS12_381_G1_Element"
+    ],
+    "Prelude.G2Element": [
+      "plutus-tx",
+      "PlutusTx.Builtins",
+      "BuiltinBLS12_381_G2_Element"
     ]
   },
   "classesConfig": {

--- a/libs/lbf-prelude/Prelude.lbf
+++ b/libs/lbf-prelude/Prelude.lbf
@@ -28,6 +28,16 @@ opaque Text
 instance Eq Text
 instance Json Text
 
+opaque G1Element
+
+instance Eq G1Element
+instance Json G1Element
+
+opaque G2Element
+
+instance Eq G2Element
+instance Json G2Element
+
 opaque Maybe a
 
 instance Eq (Maybe a) :- Eq a

--- a/runtimes/haskell/lbr-plutarch/lbr-plutarch.cabal
+++ b/runtimes/haskell/lbr-plutarch/lbr-plutarch.cabal
@@ -90,8 +90,8 @@ library
   import:          common-language
   build-depends:
     , base
-    , plutarch
-    , plutarch-ledger-api
+    , plutarch             >=1.14.0
+    , plutarch-ledger-api  >=3.7.0
 
   hs-source-dirs:  src
   exposed-modules:
@@ -107,7 +107,7 @@ test-suite tests
     , base
     , hedgehog
     , lbr-plutarch
-    , plutarch
+    , plutarch        >=1.14.0
     , tasty
     , tasty-hedgehog
     , tasty-hunit

--- a/testsuites/lbt-plutus/lbt-plutus-haskell/cabal.project
+++ b/testsuites/lbt-plutus/lbt-plutus-haskell/cabal.project
@@ -1,5 +1,10 @@
 packages: ./.
 
+source-repository-package
+  type: git
+  location: https://github.com/mlabs-haskell/hbls-need-push-access.git
+  tag: 6b92e81481f5409c624e1b9b22eefc7d3abd81fb
+
 tests: true
 -- Uniform plutus version across all LambdaBuffers projects (van Rossem/PV11 compatible,
 -- newest supported by plutarch 1.14.0)

--- a/testsuites/lbt-plutus/lbt-plutus-plutarch/cabal.project
+++ b/testsuites/lbt-plutus/lbt-plutus-plutarch/cabal.project
@@ -2,6 +2,12 @@ packages: ./.
 
 tests: true
 
+source-repository-package
+  type: git
+  location: https://github.com/mlabs-haskell/hbls-need-push-access.git
+  tag: 6b92e81481f5409c624e1b9b22eefc7d3abd81fb
+
+
 allow-newer:
   -- TODO(szg251): Allow once the below issue is resolved
   -- https://github.com/phadej/vec/issues/121

--- a/testsuites/lbt-plutus/lbt-plutus-plutustx/cabal.project
+++ b/testsuites/lbt-plutus/lbt-plutus-plutustx/cabal.project
@@ -2,6 +2,11 @@ packages: ./.
 
 tests: true
 
+source-repository-package
+  type: git
+  location: https://github.com/mlabs-haskell/hbls-need-push-access.git
+  tag: 6b92e81481f5409c624e1b9b22eefc7d3abd81fb
+
 allow-newer:
   -- TODO(szg251): Allow once the below issue is resolved
   -- https://github.com/phadej/vec/issues/121

--- a/testsuites/lbt-prelude/lbt-prelude-haskell/cabal.project
+++ b/testsuites/lbt-prelude/lbt-prelude-haskell/cabal.project
@@ -1,3 +1,8 @@
 packages: ./.
 
+source-repository-package
+  type: git
+  location: https://github.com/mlabs-haskell/hbls-need-push-access.git
+  tag: 6b92e81481f5409c624e1b9b22eefc7d3abd81fb
+
 tests: true


### PR DESCRIPTION
This gets the checks passing for the haskell backends after adding BLS primitives to the LB prelude, but this is almost certainly not the _right_ way to do things (which requires putting Koz's package on hackage). 

I'm putting this up primarily so I can look at a pretty GH diff and more easily keep track of what I've changed. 